### PR TITLE
[chore] SecurityConfig 초기 설정

### DIFF
--- a/src/main/java/everTale/everTale_be/global/config/SecurityConfig.java
+++ b/src/main/java/everTale/everTale_be/global/config/SecurityConfig.java
@@ -1,0 +1,45 @@
+package everTale.everTale_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    private static final String[] SWAGGER_WHITELIST = {
+            "/swagger-ui/**",             // Swagger UI 페이지
+            "/v3/api-docs/**",            // OpenAPI 문서
+            "/swagger-resources/**",      // Swagger 리소스
+            "/webjars/**"                 // Swagger UI 정적 리소스 (JS, CSS)
+    };
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(SWAGGER_WHITELIST).permitAll()
+                        .requestMatchers("/**").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+}


### PR DESCRIPTION
## 연관 이슈
close #7 

## 📌 개요
Spring Security 기본 설정

## 🔧 작업 내용

Swagger UI 접근 허용하여 API 테스트 가능하도록 설정
<img width="1467" alt="스크린샷 2025-06-26 오후 8 47 25" src="https://github.com/user-attachments/assets/571159c6-4041-4849-9413-03e10b99e4cb" />

## 📝 논의 사항
1. Swagger 테스트를 위한 임시 설정이고 추후 JWT 적용 시 인증 및 인가 로직 강화 예정입니다.
2. 초반에 `${SPRING_SERVER_SERVLET_CONTEXT_PATH}`를 `/api`로 설정했던 것 같은데요, `http://localhost:8080/api/swagger-ui/index.html`로 접속을 해보니 `Whitelabel Error`가 떠서 찾아보니 `springdoc-openapi`는 Spring Boot의 `context-path`를 지원하지 않는다고 하네요.. 그래서 OpenAPI 엔드포인트는 항상 루트 컨텍스트에서 비롯(?)된다고 합니다. 그래서 그냥 `http://localhost:8080/swagger-ui/index.html` 이 주소로 접속하시면 정상적으로 화면이 뜨는거 확인하실 수 있습니다~!
<img width="476" alt="스크린샷 2025-06-26 오후 8 51 32" src="https://github.com/user-attachments/assets/fb9ef01e-9326-45ea-826d-40f4d3180f1b" />

---
