### PR TITLE
[feature] Auth 관련 api 구현 (JWT, 소셜 로그인 포함)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+	// JWT (JJWT)
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
+++ b/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
@@ -4,14 +4,11 @@ import everTale.everTale_be.auth.dto.request.*;
 import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
 import everTale.everTale_be.auth.jwt.CustomUserDetails;
 import everTale.everTale_be.auth.service.AuthService;
+import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -26,55 +23,49 @@ public class AuthController {
     // 일반 회원가입
     @Operation(summary = "일반 회원가입", description = "이메일, 비밀번호, 이름, 전화번호, 기관명으로 회원가입을 진행합니다.")
     @PostMapping("/signup")
-    public ResponseEntity<Void> signup(@Valid @RequestBody SignUpRequestDto requestDto){
+    public ApiResponse<String> signup(@Valid @RequestBody SignUpRequestDto requestDto){
         authService.signup(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).build();
+        return ApiResponse.onSuccess("회원가입이 성공적으로 완료되었습니다.");
     }
 
     // 일반 로그인
     @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 토큰을 발급합니다.")
     @PostMapping("/login")
-    public ResponseEntity<LoginTokenResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto){
+    public ApiResponse<LoginTokenResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto){
         LoginTokenResponseDto responseDto = authService.login(requestDto);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(responseDto);
     }
 
     // 네이버 로그인
-//    @PostMapping("/naver-login")
-//    public ResponseEntity<LoginTokenResponseDto> naverLogin(@Valid @RequestBody NaverLoginRequestDto requestDto){
-//        LoginTokenResponseDto responseDto = authService.naverLogin(requestDto);
-//        return ResponseEntity.ok(responseDto);
-//    }
-
     @GetMapping("/naver-login")
     @Operation(summary = "네이버 로그인", description = "네이버 소셜 로그인. OAuth 인가 코드와 state를 통해 토큰을 발급합니다.")
-    public ResponseEntity<LoginTokenResponseDto> naverLogin(@RequestParam String code,
+    public ApiResponse<LoginTokenResponseDto> naverLogin(@RequestParam String code,
                                                             @RequestParam String state) {
         LoginTokenResponseDto responseDto = authService.naverLogin(code, state);
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(responseDto);
     }
 
     // 토큰 재발급
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급", description = "Refresh Token을 통해 Access Token과 Refresh Token을 재발급합니다.")
-    public ResponseEntity<LoginTokenResponseDto> reissue(@Valid @RequestBody ReissueRequestDto requestDto){
+    public ApiResponse<LoginTokenResponseDto> reissue(@Valid @RequestBody ReissueRequestDto requestDto){
         LoginTokenResponseDto responseDto = authService.reissue(requestDto.getRefreshToken());
-        return ResponseEntity.ok(responseDto);
+        return ApiResponse.onSuccess(responseDto);
     }
 
     // 로그아웃
     @Operation(summary = "로그아웃", description = "현재 로그인한 사용자의 토큰을 만료 처리합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails){
+    public ApiResponse<String> logout(@AuthenticationPrincipal CustomUserDetails userDetails){
         authService.logout(userDetails.getUserId());
-        return ResponseEntity.noContent().build();
+        return ApiResponse.onSuccess("로그아웃이 성공적으로 완료되었습니다.");
     }
 
     // 회원 탈퇴
     @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자를 탈퇴 처리합니다. 회원정보가 익명화됩니다.")
     @DeleteMapping("/withdraw")
-    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails){
+    public ApiResponse<String> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails){
         authService.withdraw(userDetails.getUserId());
-        return ResponseEntity.noContent().build();
+        return ApiResponse.onSuccess("회원 탈퇴가 성공적으로 완료되었습니다.");
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
+++ b/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
@@ -1,0 +1,80 @@
+package everTale.everTale_be.auth.controller;
+
+import everTale.everTale_be.auth.dto.request.*;
+import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
+import everTale.everTale_be.auth.jwt.CustomUserDetails;
+import everTale.everTale_be.auth.service.AuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    // 일반 회원가입
+    @Operation(summary = "일반 회원가입", description = "이메일, 비밀번호, 이름, 전화번호, 기관명으로 회원가입을 진행합니다.")
+    @PostMapping("/signup")
+    public ResponseEntity<Void> signup(@Valid @RequestBody SignUpRequestDto requestDto){
+        authService.signup(requestDto);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    // 일반 로그인
+    @Operation(summary = "일반 로그인", description = "이메일과 비밀번호로 로그인하여 토큰을 발급합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<LoginTokenResponseDto> login(@Valid @RequestBody LoginRequestDto requestDto){
+        LoginTokenResponseDto responseDto = authService.login(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 네이버 로그인
+//    @PostMapping("/naver-login")
+//    public ResponseEntity<LoginTokenResponseDto> naverLogin(@Valid @RequestBody NaverLoginRequestDto requestDto){
+//        LoginTokenResponseDto responseDto = authService.naverLogin(requestDto);
+//        return ResponseEntity.ok(responseDto);
+//    }
+
+    @GetMapping("/naver-login")
+    @Operation(summary = "네이버 로그인", description = "네이버 소셜 로그인. OAuth 인가 코드와 state를 통해 토큰을 발급합니다.")
+    public ResponseEntity<LoginTokenResponseDto> naverLogin(@RequestParam String code,
+                                                            @RequestParam String state) {
+        LoginTokenResponseDto responseDto = authService.naverLogin(code, state);
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 토큰 재발급
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급", description = "Refresh Token을 통해 Access Token과 Refresh Token을 재발급합니다.")
+    public ResponseEntity<LoginTokenResponseDto> reissue(@Valid @RequestBody ReissueRequestDto requestDto){
+        LoginTokenResponseDto responseDto = authService.reissue(requestDto.getRefreshToken());
+        return ResponseEntity.ok(responseDto);
+    }
+
+    // 로그아웃
+    @Operation(summary = "로그아웃", description = "현재 로그인한 사용자의 토큰을 만료 처리합니다.")
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails userDetails){
+        authService.logout(userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+
+    // 회원 탈퇴
+    @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자를 탈퇴 처리합니다. 회원정보가 익명화됩니다.")
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails){
+        authService.withdraw(userDetails.getUserId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/request/InstitutionRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/InstitutionRequestDto.java
@@ -1,0 +1,12 @@
+package everTale.everTale_be.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "기관 수정 DTO")
+public class InstitutionRequestDto {
+
+    @Schema(description = "기관명", example = "새싹 유치원")
+    private String institution;
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/request/LoginRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/LoginRequestDto.java
@@ -1,0 +1,23 @@
+package everTale.everTale_be.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "일반 로그인 요청 DTO")
+public class LoginRequestDto {
+
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    @Schema(description = "이메일", example = "ewhacse@gmail.com")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "비밀번호", example = "password123!")
+    private String password;
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/request/NaverLoginRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/NaverLoginRequestDto.java
@@ -1,0 +1,17 @@
+package everTale.everTale_be.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "네이버 로그인 요청 DTO")
+public class NaverLoginRequestDto {
+    @Schema(description = "인가 코드", example = "AAAA-BBBB-CCCC")
+    private String code;
+
+    @Schema(description = "상태값", example = "XYZ123")
+    private String state;
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/request/ReissueRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/ReissueRequestDto.java
@@ -1,0 +1,15 @@
+package everTale.everTale_be.auth.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "토큰 재발급 요청 DTO")
+public class ReissueRequestDto {
+
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI...")
+    private String refreshToken;
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/SignUpRequestDto.java
@@ -1,0 +1,38 @@
+package everTale.everTale_be.auth.dto.request;
+
+import everTale.everTale_be.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "회원가입 요청 DTO")
+public class SignUpRequestDto {
+
+    @Email
+    @NotBlank(message = "이메일은 필수입니다.")
+    @Schema(description = "이메일", example = "ewhacse@gmail.com")
+    private String email;
+
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Schema(description = "비밀번호", example = "password123!")
+    private String password;
+
+    @Size(max = 10)
+    @NotBlank(message = "이름은 필수입니다.")
+    @Schema(description = "이름", example = "김이화")
+    private String username;
+
+    @NotBlank(message = "핸드폰 번호는 필수입니다.")
+    @Schema(description = "전화번호", example = "010-1234-5678")
+    private String phone;
+
+    @NotBlank(message = "기관명은 필수입니다.")
+    @Schema(description = "기관명", example = "새싹 유치원")
+    private String institution;
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/request/SignUpRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/SignUpRequestDto.java
@@ -1,9 +1,9 @@
 package everTale.everTale_be.auth.dto.request;
 
-import everTale.everTale_be.domain.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -20,6 +20,10 @@ public class SignUpRequestDto {
     private String email;
 
     @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}$",
+            message = "비밀번호는 영문자, 숫자, 특수문자를 포함한 8자 이상이어야 합니다."
+    )
     @Schema(description = "비밀번호", example = "password123!")
     private String password;
 

--- a/src/main/java/everTale/everTale_be/auth/dto/response/LoginTokenResponseDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/response/LoginTokenResponseDto.java
@@ -1,0 +1,34 @@
+package everTale.everTale_be.auth.dto.response;
+
+import everTale.everTale_be.auth.jwt.JwtUtil;
+import everTale.everTale_be.domain.user.domain.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "로그인 토큰 응답 DTO")
+public class LoginTokenResponseDto {
+
+    @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1...")
+    private String accessToken;
+    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1...")
+    private String refreshToken;
+    @Schema(description = "Access Token 만료 시간 (timestamp, ms)", example = "1717654800000")
+    private long accessExp;
+    @Schema(description = "Refresh Token 만료 시간 (timestamp, ms)", example = "1718259600000")
+    private long refreshExp;
+    @Schema(description = "유저 ID", example = "1")
+    private Long userId;
+
+    public static LoginTokenResponseDto of(User user, String accessToken, String refreshToken, JwtUtil jwtUtil){
+        return LoginTokenResponseDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessExp(System.currentTimeMillis() + jwtUtil.getAccessTokenExpireTime())
+                .refreshExp(System.currentTimeMillis() + jwtUtil.getRefreshTokenExpireTime())
+                .userId(user.getUserId())
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/response/NaverTokenResponseDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/response/NaverTokenResponseDto.java
@@ -1,0 +1,28 @@
+package everTale.everTale_be.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "네이버 로그인 토큰 응답 DTO")
+public class NaverTokenResponseDto {
+
+    @JsonProperty("access_token")
+    @Schema(description = "Access Token", example = "AAAABBBBCCCC")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    @Schema(description = "Refresh Token", example = "XXXXYYYYZZZZ")
+    private String refreshToken;
+
+    @JsonProperty("token_type")
+    @Schema(description = "토큰 타입", example = "bearer")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    @Schema(description = "Access Token 만료 시간 (초 단위)", example = "3600")
+    private String expiresIn;
+}

--- a/src/main/java/everTale/everTale_be/auth/dto/response/UserInfoResponseDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/response/UserInfoResponseDto.java
@@ -1,0 +1,33 @@
+package everTale.everTale_be.auth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "네이버 사용자 정보 응답 DTO")
+public class UserInfoResponseDto {
+
+    @JsonProperty("response")
+    @Schema(description = "응답 데이터")
+    private Response response;
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "네이버 사용자 정보")
+    public static class Response {
+        @Schema(description = "네이버 사용자 ID", example = "ABC123DEF456")
+        private String id;
+
+        @Schema(description = "이메일", example = "ewhacse@naver.com")
+        private String email;
+
+        @Schema(description = "이름", example = "김이화")
+        private String name;
+
+        @Schema(description = "전화번호", example = "010-1234-5678")
+        private String mobile;
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/jwt/CustomUserDetails.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/CustomUserDetails.java
@@ -1,0 +1,58 @@
+package everTale.everTale_be.auth.jwt;
+
+import everTale.everTale_be.domain.user.domain.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import lombok.Getter;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+    private final String email;
+    private final String username;
+
+    public CustomUserDetails(User user) {
+        this.userId = user.getUserId();
+        this.email = user.getEmail();
+        this.username = user.getUsername();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> "ROLE_USER");
+    }
+
+    @Override
+    public String getPassword() {
+        return null; // JWT에서는 비밀번호 필요 없음
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtFilter.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtFilter.java
@@ -1,0 +1,35 @@
+package everTale.everTale_be.auth.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException{
+
+        String token = jwtProvider.resolveToken(request);
+
+        if (token != null && jwtProvider.validateToken(token)) {
+            Authentication authentication = jwtProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
@@ -1,0 +1,50 @@
+package everTale.everTale_be.auth.jwt;
+
+import everTale.everTale_be.domain.user.domain.User;
+import everTale.everTale_be.domain.user.repository.UserRepository;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    // 헤더에서 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        return (bearerToken != null && bearerToken.startsWith("Bearer "))
+                ? bearerToken.substring(7) // Bearer 제거하고 토큰만 반환
+                : null;
+    }
+
+    // 토큰 유효성 검사
+    public boolean validateToken(String token) {
+        return jwtUtil.validateToken(token);
+    }
+
+    // 토큰에서 Authentication 객체 생성
+    public Authentication getAuthentication(String token) {
+        Claims claims = jwtUtil.extractClaims(token);
+        Long userId = claims.get("userId", Long.class);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+
+        return new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtUtil.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtUtil.java
@@ -1,0 +1,84 @@
+package everTale.everTale_be.auth.jwt;
+
+import everTale.everTale_be.domain.user.domain.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+    private final SecretKey secretKey;
+
+    public JwtUtil(@Value("${SECRET_KEY}") String secret) {
+        this.secretKey = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+    }
+
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60; // 1시간
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; // 1주일
+
+    // JWT access token 생성
+    public String generateAccessToken(User user) {
+        Date generated = new Date(System.currentTimeMillis());
+        Date accessTokenExpiredAt = new Date(generated.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
+
+        return Jwts.builder()
+                .claim("userId", user.getUserId())
+                .issuedAt(generated)
+                .expiration(accessTokenExpiredAt)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // JWT refresh token 생성
+    public String generateRefreshToken(User user) {
+        Date generated = new Date(System.currentTimeMillis());
+        Date refreshTokenExpiredAt = new Date(generated.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
+
+        return Jwts.builder()
+                .claim("userId", user.getUserId())
+                .issuedAt(generated)
+                .expiration(refreshTokenExpiredAt)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    // Claim 추출
+    public Claims extractClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    // 유효성 검사
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (Exception e) {
+            log.error("JWT 유효성 실패: {} - {}", e.getClass().getSimpleName(), e.getMessage());
+            return false;
+        }
+    }
+
+    public long getAccessTokenExpireTime() {
+        return ACCESS_TOKEN_EXPIRE_TIME;
+    }
+
+    public long getRefreshTokenExpireTime() {
+        return REFRESH_TOKEN_EXPIRE_TIME;
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -9,7 +9,9 @@ import everTale.everTale_be.domain.user.domain.Enum.LoginProvider;
 import everTale.everTale_be.domain.user.domain.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
-import everTale.everTale_be.global.apiPayload.exception.GeneralException;
+import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
+import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
+import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import io.jsonwebtoken.Claims;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +32,7 @@ public class AuthService {
         boolean exists = userRepository.existsByEmailAndLoginProvider(requestDto.getEmail(), LoginProvider.LOCAL);
 
         if (exists) {
-            throw new GeneralException(ErrorStatus.ALREADY_EXISTS_EMAIL);
+            throw new BadRequestHandler(ErrorStatus.ALREADY_EXISTS_EMAIL);
         }
         User user = User.builder()
                 .email(requestDto.getEmail())
@@ -46,9 +48,9 @@ public class AuthService {
     // 일반 로그인
     public LoginTokenResponseDto login(LoginRequestDto requestDto){
         User user = userRepository.findByEmailAndLoginProvider(requestDto.getEmail(), LoginProvider.LOCAL)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
         if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
-            throw new GeneralException(ErrorStatus.INVALID_CREDENTIALS);
+            throw new UnAuthorizedHandler(ErrorStatus.INVALID_CREDENTIALS);
         }
 
         String accessToken = jwtUtil.generateAccessToken(user);
@@ -97,11 +99,11 @@ public class AuthService {
 
         String storedRefreshToken = tokenAuthService.getRefreshToken(userId);
         if (!storedRefreshToken.equals(refreshToken)) {
-            throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN);
+            throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
         User user = userRepository.findById(userId)
-                .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
         String newAccessToken = jwtUtil.generateAccessToken(user);
         String newRefreshToken = jwtUtil.generateRefreshToken(user);
 
@@ -119,7 +121,7 @@ public class AuthService {
     // 회원 탈퇴
     public void withdraw(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
         userRepository.anonymizeUser(userId);
         tokenAuthService.deleteRefreshToken(userId);
     }

--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -1,0 +1,126 @@
+package everTale.everTale_be.auth.service;
+
+import everTale.everTale_be.auth.dto.request.LoginRequestDto;
+import everTale.everTale_be.auth.dto.request.SignUpRequestDto;
+import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
+import everTale.everTale_be.auth.dto.response.UserInfoResponseDto;
+import everTale.everTale_be.auth.jwt.JwtUtil;
+import everTale.everTale_be.domain.user.domain.Enum.LoginProvider;
+import everTale.everTale_be.domain.user.domain.User;
+import everTale.everTale_be.domain.user.repository.UserRepository;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtUtil jwtUtil;
+    private final TokenAuthService tokenAuthService;
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+    private final NaverService naverService;
+
+    // 일반 회원가입
+    public void signup(SignUpRequestDto requestDto) {
+        boolean exists = userRepository.existsByEmailAndLoginProvider(requestDto.getEmail(), LoginProvider.LOCAL);
+
+        if (exists) {
+            throw new GeneralException(ErrorStatus.ALREADY_EXISTS_EMAIL);
+        }
+        User user = User.builder()
+                .email(requestDto.getEmail())
+                .password(passwordEncoder.encode(requestDto.getPassword()))
+                .username(requestDto.getUsername())
+                .phone(requestDto.getPhone())
+                .institution(requestDto.getInstitution())
+                .loginProvider(LoginProvider.LOCAL) // 일반 회원가입은 LOCAL
+                .build();
+        userRepository.save(user);
+    }
+
+    // 일반 로그인
+    public LoginTokenResponseDto login(LoginRequestDto requestDto){
+        User user = userRepository.findByEmailAndLoginProvider(requestDto.getEmail(), LoginProvider.LOCAL)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new GeneralException(ErrorStatus.INVALID_CREDENTIALS);
+        }
+
+        String accessToken = jwtUtil.generateAccessToken(user);
+        String refreshToken = jwtUtil.generateRefreshToken(user);
+
+        tokenAuthService.saveRefreshToken(user.getUserId(), refreshToken);
+
+        return LoginTokenResponseDto.of(user, accessToken, refreshToken, jwtUtil);
+    }
+
+    // 네이버 로그인
+    public LoginTokenResponseDto naverLogin(String code, String state) {
+        String naverAccessToken = naverService.getNaverAccessToken(code, state);
+        UserInfoResponseDto userInfo = naverService.getNaverUser(naverAccessToken);
+        User user = findOrCreateUserForNaver(userInfo);
+
+        String accessToken = jwtUtil.generateAccessToken(user);
+        String refreshToken = jwtUtil.generateRefreshToken(user);
+
+        tokenAuthService.saveRefreshToken(user.getUserId(), refreshToken);
+
+        return LoginTokenResponseDto.of(user, accessToken, refreshToken, jwtUtil);
+    }
+
+    public User findOrCreateUserForNaver(UserInfoResponseDto responseDto){
+        return userRepository.findByEmailAndLoginProvider(responseDto.getResponse().getEmail(), LoginProvider.NAVER)
+                .orElseGet(()-> createUserForNaver(responseDto));
+    }
+
+    public User createUserForNaver(UserInfoResponseDto responseDto){
+        User user = User.builder()
+                .email(responseDto.getResponse().getEmail())
+                .username(responseDto.getResponse().getName())
+                .phone(responseDto.getResponse().getMobile())
+                .password("")
+                .institution(null)
+                .loginProvider(LoginProvider.NAVER)
+                .build();
+        return userRepository.save(user);
+    }
+
+    // 토큰 재발급
+    public LoginTokenResponseDto reissue(String refreshToken){
+        Claims claims = jwtUtil.extractClaims(refreshToken);
+        Long userId = claims.get("userId", Long.class);
+
+        String storedRefreshToken = tokenAuthService.getRefreshToken(userId);
+        if (!storedRefreshToken.equals(refreshToken)) {
+            throw new GeneralException(ErrorStatus.INVALID_REFRESH_TOKEN);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+        String newAccessToken = jwtUtil.generateAccessToken(user);
+        String newRefreshToken = jwtUtil.generateRefreshToken(user);
+
+        tokenAuthService.deleteRefreshToken(userId);
+        tokenAuthService.saveRefreshToken(userId, newRefreshToken);
+
+        return LoginTokenResponseDto.of(user, newAccessToken, newRefreshToken, jwtUtil);
+    }
+
+    // 로그아웃
+    public void logout(Long userId) {
+        tokenAuthService.deleteRefreshToken(userId);
+    }
+
+    // 회원 탈퇴
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+        userRepository.anonymizeUser(userId);
+        tokenAuthService.deleteRefreshToken(userId);
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/service/NaverService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/NaverService.java
@@ -1,0 +1,63 @@
+package everTale.everTale_be.auth.service;
+
+import everTale.everTale_be.auth.dto.response.UserInfoResponseDto;
+import everTale.everTale_be.auth.dto.response.NaverTokenResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Objects;
+
+@Service
+public class NaverService {
+
+    @Value("${naver.client-id}")
+    private String clientId;
+
+    @Value("${naver.client-secret}")
+    private String clientSecret;
+
+    @Value("${naver.redirect-uri}")
+    private String redirectUri;
+
+    public String getNaverAccessToken(String code, String state) {
+        String tokenUrl = "https://nid.naver.com/oauth2.0/token";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", clientId);
+        params.add("client_secret", clientSecret);
+        params.add("redirect_uri", redirectUri);
+        params.add("code", code);
+        params.add("state", state);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<NaverTokenResponseDto> response =
+                restTemplate.postForEntity(tokenUrl, request, NaverTokenResponseDto.class);
+
+        return Objects.requireNonNull(response.getBody()).getAccessToken();
+    }
+
+    public UserInfoResponseDto getNaverUser(String accessToken) {
+        String url = "https://openapi.naver.com/v1/nid/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        ResponseEntity<UserInfoResponseDto> response =
+                restTemplate.exchange(url, HttpMethod.GET, request, UserInfoResponseDto.class);
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/everTale/everTale_be/auth/service/TokenAuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/TokenAuthService.java
@@ -1,0 +1,45 @@
+package everTale.everTale_be.auth.service;
+
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class TokenAuthService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "refreshToken:";
+
+    // token 저장
+    public void saveRefreshToken(Long userId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                PREFIX + userId,   // Key
+                refreshToken,           // Value
+                7, TimeUnit.DAYS        // 유효기간
+        );
+    }
+
+    // token 조회
+    public String getRefreshToken(Long userId) {
+        String token = redisTemplate.opsForValue().get(PREFIX + userId);
+        if (token == null) {
+            throw new GeneralException(ErrorStatus.NOT_FOUND_REFRESH_TOKEN);
+        }
+        return token;
+    }
+
+    // token 삭제
+    public void deleteRefreshToken(Long userId) {
+        redisTemplate.delete(PREFIX + userId);
+    }
+
+    // token 존재 여부
+    public boolean existsRefreshToken(Long userId) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + userId));
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/user/controller/UserController.java
+++ b/src/main/java/everTale/everTale_be/domain/user/controller/UserController.java
@@ -3,7 +3,9 @@ package everTale.everTale_be.domain.user.controller;
 import everTale.everTale_be.auth.dto.request.InstitutionRequestDto;
 import everTale.everTale_be.auth.jwt.CustomUserDetails;
 import everTale.everTale_be.domain.user.service.UserService;
-import org.springframework.http.ResponseEntity;
+import everTale.everTale_be.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -11,15 +13,17 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Tag(name = "User", description = "회원 관련 API")
 public class UserController {
 
     private final UserService userService;
 
     // 기관 정보
+    @Operation(summary = "기관 정보 수정", description = "로그인한 사용자의 기관 정보를 수정합니다.")
     @PatchMapping("/institution")
-    public ResponseEntity<Void> addAdditionalInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                  @RequestBody InstitutionRequestDto request) {
+    public ApiResponse<String> updateInstitution(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                 @RequestBody InstitutionRequestDto request) {
         userService.addAdditionalInfo(userDetails.getUserId(), request);
-        return ResponseEntity.noContent().build();
+        return ApiResponse.onSuccess("기관이 성공적으로 변경되었습니다.");
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/user/controller/UserController.java
+++ b/src/main/java/everTale/everTale_be/domain/user/controller/UserController.java
@@ -1,0 +1,25 @@
+package everTale.everTale_be.domain.user.controller;
+
+import everTale.everTale_be.auth.dto.request.InstitutionRequestDto;
+import everTale.everTale_be.auth.jwt.CustomUserDetails;
+import everTale.everTale_be.domain.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/members")
+public class UserController {
+
+    private final UserService userService;
+
+    // 기관 정보
+    @PatchMapping("/institution")
+    public ResponseEntity<Void> addAdditionalInfo(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                                  @RequestBody InstitutionRequestDto request) {
+        userService.addAdditionalInfo(userDetails.getUserId(), request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/user/domain/Enum/LoginProvider.java
+++ b/src/main/java/everTale/everTale_be/domain/user/domain/Enum/LoginProvider.java
@@ -1,0 +1,5 @@
+package everTale.everTale_be.domain.user.domain.Enum;
+
+public enum LoginProvider {
+    LOCAL, NAVER, KAKAO,
+}

--- a/src/main/java/everTale/everTale_be/domain/user/domain/User.java
+++ b/src/main/java/everTale/everTale_be/domain/user/domain/User.java
@@ -1,0 +1,68 @@
+package everTale.everTale_be.domain.user.domain;
+
+import everTale.everTale_be.domain.user.domain.Enum.LoginProvider;
+import everTale.everTale_be.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "user",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_email_provider",
+                columnNames = {"email", "login_provider"}
+        )
+)
+public class User extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private long userId;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String email;
+
+    private String password;
+
+    @Column(nullable = false)
+    private String phone;
+
+    private String institution;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "login_provider", nullable = false)
+    private LoginProvider loginProvider;
+
+//    @OneToMany(mappedBy = "child", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Child> childs = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "voice", cascade = CascadeType.ALL, orphanRemoval = true)
+//    private List<Voice> voices = new ArrayList<>();
+
+    @Builder
+    public User(String username,
+                String email,
+                String password,
+                String phone,
+                String institution,
+                LoginProvider loginProvider) {
+        this.username = username;
+        this.email = email;
+        this.password = password;
+        this.phone = phone;
+        this.institution = institution;
+        this.loginProvider = loginProvider;
+    }
+
+    public void updateInstitution(String institution) {
+        this.institution = institution;
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/user/repository/UserRepository.java
@@ -1,0 +1,27 @@
+package everTale.everTale_be.domain.user.repository;
+
+import everTale.everTale_be.domain.user.domain.Enum.LoginProvider;
+import everTale.everTale_be.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmailAndLoginProvider(String email, LoginProvider loginProvider);
+
+    Optional<User> findByEmailAndLoginProvider(String email, LoginProvider loginProvider);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE User u SET " +
+            "u.email = CONCAT('deleted_', STR(:userId), '_', FUNCTION('UUID')), " +
+            "u.username = '알 수 없음', " +
+            "u.phone = '알 수 없음' " +
+            "WHERE u.userId = :userId")
+    void anonymizeUser(@Param("userId") Long userId);
+}

--- a/src/main/java/everTale/everTale_be/domain/user/service/UserService.java
+++ b/src/main/java/everTale/everTale_be/domain/user/service/UserService.java
@@ -1,0 +1,24 @@
+package everTale.everTale_be.domain.user.service;
+
+import everTale.everTale_be.auth.dto.request.InstitutionRequestDto;
+import everTale.everTale_be.domain.user.domain.User;
+import everTale.everTale_be.domain.user.repository.UserRepository;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void addAdditionalInfo(Long userId, InstitutionRequestDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+        user.updateInstitution(requestDto.getInstitution());
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/user/service/UserService.java
+++ b/src/main/java/everTale/everTale_be/domain/user/service/UserService.java
@@ -4,7 +4,7 @@ import everTale.everTale_be.auth.dto.request.InstitutionRequestDto;
 import everTale.everTale_be.domain.user.domain.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
-import everTale.everTale_be.global.apiPayload.exception.GeneralException;
+import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,7 +18,7 @@ public class UserService {
     @Transactional
     public void addAdditionalInfo(Long userId, InstitutionRequestDto requestDto) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND_USER));
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
         user.updateInstitution(requestDto.getInstitution());
     }
 }

--- a/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
@@ -18,9 +18,13 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Not Found
     NOT_FOUND_USER(HttpStatus.NOT_FOUND, "USER404", "해당 유저를 찾을 수 없습니다."),
+    NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "TOKEN404", "리프레시 토큰이 존재하지 않습니다."),
 
     // User 관련 에러
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
+    ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "USER409", "이미 존재하는 이메일입니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER401", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER4012", "유효하지 않은 리프레시 토큰입니다."),
 
     //s3 관련 에러
     NO_FILE_EXTENTION(HttpStatus.BAD_REQUEST, "UPLOAD400", "파일의 이름에 확장자가 존재하지 않습니다."),

--- a/src/main/java/everTale/everTale_be/global/config/RedisConfig.java
+++ b/src/main/java/everTale/everTale_be/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package everTale.everTale_be.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/everTale/everTale_be/global/config/SecurityConfig.java
+++ b/src/main/java/everTale/everTale_be/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package everTale.everTale_be.global.config;
 
+import everTale.everTale_be.auth.jwt.JwtFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,6 +10,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -27,7 +29,7 @@ public class SecurityConfig {
     };
 
     @Bean
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, JwtFilter jwtFilter) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -38,8 +40,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(SWAGGER_WHITELIST).permitAll()
                         .requestMatchers("/**").permitAll()
+                        .requestMatchers("/api/auth/**").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/everTale/everTale_be/global/entity/BaseTimeEntity.java
+++ b/src/main/java/everTale/everTale_be/global/entity/BaseTimeEntity.java
@@ -5,7 +5,7 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
@@ -19,7 +19,7 @@ public class BaseTimeEntity {
     @Column(name="created_at", updatable = false, columnDefinition = "timestamp")
     private LocalDateTime createdAt;
 
-    @LastModifiedBy
-    @Column(name="updated_at",columnDefinition = "timestmap")
+    @LastModifiedDate
+    @Column(name="updated_at",columnDefinition = "timestamp")
     private LocalDateTime updatedAt;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,10 +16,10 @@ spring:
         use_sql_comments: true
         jdbc:
           time_zone: Asia/Seoul
-#  data:
-#    redis:
-#      host: localhost
-#      port: 6379
+  data:
+    redis:
+      host: localhost
+      port: 6379
 
   servlet:
     multipart:


### PR DESCRIPTION
## 연관 이슈
close #4 

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 인증(Auth) 관련 API 구현
- 회원가입, 로그인, 로그아웃, 토큰 재발급, 회원 탈퇴, 네이버 소셜 로그인 기능 구현

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- 일반 회원가입
<img width="919" alt="스크린샷 2025-06-30 오전 12 54 38" src="https://github.com/user-attachments/assets/4f19391b-1558-4e43-932b-6c7085d39900" />
- 일반 로그인
<img width="917" alt="스크린샷 2025-06-30 오전 12 54 51" src="https://github.com/user-attachments/assets/c53f4206-1b6c-4997-9627-278caa3267ac" />
- 네이버 로그인
<img width="1465" alt="스크린샷 2025-06-30 오전 12 59 26" src="https://github.com/user-attachments/assets/5ed7ff22-8821-468a-a0b6-ed022c92a469" />
- 기관 수정
<img width="919" alt="스크린샷 2025-06-30 오전 12 55 50" src="https://github.com/user-attachments/assets/df74db28-d5bc-482e-8e15-43e1d435570f" />
- 토큰 재발급
<img width="919" alt="스크린샷 2025-06-30 오전 1 01 18" src="https://github.com/user-attachments/assets/34af4c3b-aac7-4c20-a6bf-29c1fde5879e" />
- 로그아웃
<img width="918" alt="스크린샷 2025-06-30 오전 12 56 44" src="https://github.com/user-attachments/assets/6687b86a-3181-409d-b79d-efd20cab2b34" />
- 회원탈퇴
<img width="915" alt="스크린샷 2025-06-30 오전 12 57 01" src="https://github.com/user-attachments/assets/cd3919d1-8803-4823-bbba-41311145f806" />


## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->
- 네이버 로그인 경우는 브라우저로 URL 직접 연결해서 테스트 했습니다. Client Id, Client Secret, redirect URI는 카카오톡으로 공유하겠습니다.
브라우저 테스트 URL: https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&state=test
- 혹시 "기관 추가"가 뭔지 궁금해하실까봐 간략히 설명드리자면, 네이버로 로그인하는 사용자의 경우, 가입 후 기관을 입력하는게 따로 필요할 것 같아 만든 기능입니다.
- Swagger 문서화도 따로 해두긴 했는데, Postman으로 테스트 해보고 사진 첨부해놓았으니 참고 부탁드립니다 !
<img width="1468" alt="스크린샷 2025-06-30 오전 1 34 15" src="https://github.com/user-attachments/assets/fa98115c-e802-4b60-a5e6-e14bf206ecd7" />
---

