### PR TITLE
[feature] 로그인 사용자 정보 추출 유틸 추가 및 Access Token 블랙리스트 무효화 처리

### DIFF
--- a/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
+++ b/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
@@ -2,16 +2,16 @@ package everTale.everTale_be.auth.controller;
 
 import everTale.everTale_be.auth.dto.request.*;
 import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
-import everTale.everTale_be.auth.jwt.CustomUserDetails;
+import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.auth.service.AuthService;
 import everTale.everTale_be.domain.profile.dto.response.ProfileEnterResponseDto;
 import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Auth", description = "인증 관련 API")
 public class AuthController {
 
+    private final JwtUtil jwtUtil;
     private final AuthService authService;
     private final ProfileService profileService;
 
@@ -66,16 +67,20 @@ public class AuthController {
     // 로그아웃
     @Operation(summary = "로그아웃", description = "현재 로그인한 사용자의 토큰을 만료 처리합니다.")
     @PostMapping("/logout")
-    public ApiResponse<String> logout(@AuthenticationPrincipal CustomUserDetails userDetails){
-        authService.logout(userDetails.getUserId());
+    public ApiResponse<String> logout(HttpServletRequest request){
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        authService.logout(accessToken);
         return ApiResponse.onSuccess("로그아웃이 성공적으로 완료되었습니다.");
     }
 
     // 회원 탈퇴
     @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자를 탈퇴 처리합니다. 회원정보가 익명화됩니다.")
     @DeleteMapping("/withdraw")
-    public ApiResponse<String> withdraw(@AuthenticationPrincipal CustomUserDetails userDetails){
-        authService.withdraw(userDetails.getUserId());
+    public ApiResponse<String> withdraw(HttpServletRequest request){
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        authService.withdraw(accessToken);
         return ApiResponse.onSuccess("회원 탈퇴가 성공적으로 완료되었습니다.");
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtFilter.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtFilter.java
@@ -1,6 +1,8 @@
 package everTale.everTale_be.auth.jwt;
 
-import io.jsonwebtoken.Claims;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import everTale.everTale_be.auth.service.TokenAuthService;
+import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,12 +14,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class JwtFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;
+    private final TokenAuthService tokenAuthService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -27,18 +31,36 @@ public class JwtFilter extends OncePerRequestFilter {
 
         String token = jwtProvider.resolveToken(request);
 
-        if (token != null && jwtProvider.validateToken(token)) {
-            Claims claims = jwtProvider.getClaims(token);
-            Authentication authentication;
-            if (claims.containsKey("profileId")) {
-                // 프로필 정보가 포함된 토큰인 경우
-                authentication = jwtProvider.getAuthenticationWithProfile(token);
-            } else {
-                // 로그인만 된 상태의 토큰인 경우
-                authentication = jwtProvider.getAuthentication(token);
+        try {
+            if (token != null && jwtProvider.validateToken(token)) {
+                tokenAuthService.validateNotBlackListed(token);
+                Authentication authentication;
+
+                if (jwtProvider.isTokenContainsProfileId(token)) {
+                    // 프로필 정보가 포함된 토큰인 경우
+                    authentication = jwtProvider.getAuthenticationWithProfile(token);
+                } else {
+                    // 로그인만 된 상태의 토큰인 경우
+                    authentication = jwtProvider.getAuthentication(token);
+                }
+                SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (BadRequestHandler e) {
+            setErrorResponse(response, e.getErrorReasonHttpStatus().getCode(), e.getErrorReasonHttpStatus().getMessage());
         }
-        filterChain.doFilter(request, response);
+    }
+
+    private void setErrorResponse(HttpServletResponse response, String code, String message) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+
+        // ApiResponse 구조랑 맞추기
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(Map.of(
+                "isSuccess", false,
+                "code", code,
+                "message", message
+        ));
+        response.getWriter().write(json);
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
@@ -12,8 +12,6 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
-
 @Component
 @RequiredArgsConstructor
 public class JwtProvider {
@@ -58,10 +56,16 @@ public class JwtProvider {
 
         CustomProfileDetails customProfileDetails = new CustomProfileDetails(userId, profileId);
 
-        return new UsernamePasswordAuthenticationToken(customProfileDetails, null, List.of(() -> "ROLE_USER"));
+        return new UsernamePasswordAuthenticationToken(customProfileDetails, null, customProfileDetails.getAuthorities());
     }
 
-    public Claims getClaims(String token) {
-        return jwtUtil.extractClaims(token); // 토큰에서 claim 추출
+    public Long getUserIdFromToken(String token) {
+        Claims claims = jwtUtil.extractClaims(token);
+        return claims.get("userId", Long.class);
+    }
+
+    public boolean isTokenContainsProfileId(String token) {
+        Claims claims = jwtUtil.extractClaims(token);
+        return claims.containsKey("profileId");
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtUtil.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtUtil.java
@@ -1,10 +1,13 @@
 package everTale.everTale_be.auth.jwt;
 
 import everTale.everTale_be.domain.user.domain.User;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -39,12 +42,12 @@ public class JwtUtil {
     }
 
     // 프로필 선택 후, 프로필 ID가 추가된 JWT 토큰 생성
-    public String generateAccessTokenWithProfile(User user, Long profileId) {
+    public String generateAccessTokenWithProfile(Long userId, Long profileId) {
         Date generated = new Date(System.currentTimeMillis());
         Date accessTokenExpiredAt = new Date(generated.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
 
         return Jwts.builder()
-                .claim("userId", user.getId())  // userId
+                .claim("userId", userId)  // userId
                 .claim("profileId", profileId)  // profileId 추가
                 .issuedAt(generated)
                 .expiration(accessTokenExpiredAt)
@@ -63,6 +66,14 @@ public class JwtUtil {
                 .expiration(refreshTokenExpiredAt)
                 .signWith(secretKey)
                 .compact();
+    }
+
+    public String extractAccessToken(HttpServletRequest request) {
+        String header = request.getHeader("Authorization");
+        if (header == null || !header.startsWith("Bearer ")) {
+            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
+        }
+        return header.substring(7);
     }
 
     // Claim 추출

--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -4,7 +4,9 @@ import everTale.everTale_be.auth.dto.request.LoginRequestDto;
 import everTale.everTale_be.auth.dto.request.SignUpRequestDto;
 import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
 import everTale.everTale_be.auth.dto.response.UserInfoResponseDto;
+import everTale.everTale_be.auth.jwt.JwtProvider;
 import everTale.everTale_be.auth.jwt.JwtUtil;
+import everTale.everTale_be.domain.profile.util.UserHelper;
 import everTale.everTale_be.domain.user.domain.Enum.LoginProvider;
 import everTale.everTale_be.domain.user.domain.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
@@ -12,7 +14,6 @@ import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
-import io.jsonwebtoken.Claims;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,10 +23,12 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final JwtUtil jwtUtil;
+    private final JwtProvider jwtProvider;
     private final TokenAuthService tokenAuthService;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final NaverService naverService;
+    private final UserHelper userHelper;
 
     // 일반 회원가입
     public void signup(SignUpRequestDto requestDto) {
@@ -93,35 +96,37 @@ public class AuthService {
 
     // 토큰 재발급
     public LoginTokenResponseDto reissue(String refreshToken){
-        Claims claims = jwtUtil.extractClaims(refreshToken);
-        Long userId = claims.get("userId", Long.class);
-
-        String storedRefreshToken = tokenAuthService.getRefreshToken(userId);
-        if (!storedRefreshToken.equals(refreshToken)) {
-            throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
-        }
+        Long userId = jwtProvider.getUserIdFromToken(refreshToken);
+        tokenAuthService.validateRefreshToken(userId, refreshToken);
 
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
-        String newAccessToken = jwtUtil.generateAccessToken(user);
-        String newRefreshToken = jwtUtil.generateRefreshToken(user);
 
         tokenAuthService.deleteRefreshToken(userId);
+
+        String newAccessToken = jwtUtil.generateAccessToken(user);
+        String newRefreshToken = jwtUtil.generateRefreshToken(user);
         tokenAuthService.saveRefreshToken(userId, newRefreshToken);
 
         return LoginTokenResponseDto.of(user, newAccessToken, newRefreshToken, jwtUtil);
     }
 
     // 로그아웃
-    public void logout(Long userId) {
-        tokenAuthService.deleteRefreshToken(userId);
+    public void logout(String accessToken) {
+        User user = userHelper.getRootUser();
+        tokenAuthService.validateNotBlackListed(accessToken);
+
+        tokenAuthService.addToBlackListForAccessToken(accessToken, "LOGOUT");
+        tokenAuthService.deleteRefreshToken(user.getId());
     }
 
     // 회원 탈퇴
-    public void withdraw(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
-        userRepository.anonymizeUser(userId);
-        tokenAuthService.deleteRefreshToken(userId);
+    public void withdraw(String accessToken) {
+        User user = userHelper.getRootUser();
+        tokenAuthService.validateNotBlackListed(accessToken);
+
+        tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
+        tokenAuthService.deleteRefreshToken(user.getId());
+        userRepository.anonymizeUser(user.getId());
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/service/TokenAuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/TokenAuthService.java
@@ -1,6 +1,7 @@
 package everTale.everTale_be.auth.service;
 
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -14,6 +15,7 @@ public class TokenAuthService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private static final String PREFIX = "refreshToken:";
+    private static final String BLACKLIST_PREFIX = "blacklist:";
 
     // token 저장
     public void saveRefreshToken(Long userId, String refreshToken) {
@@ -39,7 +41,32 @@ public class TokenAuthService {
     }
 
     // token 존재 여부
-    public boolean existsRefreshToken(Long userId) {
-        return Boolean.TRUE.equals(redisTemplate.hasKey(PREFIX + userId));
+    public void validateRefreshToken(Long userId, String refreshToken) {
+        String storedRefreshToken = getRefreshToken(userId);
+        if (!storedRefreshToken.equals(refreshToken)) {
+            throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
+        }
+    }
+
+    // BlackList
+    public void addToBlackListForAccessToken(String accessToken, String reason) {
+        System.out.println("Access Token: " + accessToken);
+
+        if (accessToken == null || accessToken.isEmpty()) {
+            throw new IllegalArgumentException("Access Token is null or empty");
+        }
+        redisTemplate.opsForValue().set(
+                BLACKLIST_PREFIX + accessToken,
+                reason,
+                1000 * 60 * 60,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public void validateNotBlackListed(String token) {
+        boolean isBlackListed = Boolean.TRUE.equals(redisTemplate.hasKey(BLACKLIST_PREFIX + token));
+        if (isBlackListed) {
+            throw new BadRequestHandler(ErrorStatus.BLOCKED_TOKEN);
+        }
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
@@ -1,7 +1,6 @@
 package everTale.everTale_be.domain.profile.controller;
 
-import everTale.everTale_be.auth.jwt.CustomUserDetails;
-import everTale.everTale_be.domain.profile.domain.CustomProfileDetails;
+import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.domain.profile.dto.request.ChildProfileRequestDto;
 import everTale.everTale_be.domain.profile.dto.request.ChildProfileUpdateRequestDto;
 import everTale.everTale_be.domain.profile.dto.request.ParentProfileUpdateRequestDto;
@@ -11,9 +10,9 @@ import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -22,80 +21,78 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "Profile", description = "프로필 관리 API")
 public class ProfileController {
 
+    private final JwtUtil jwtUtil;
     private final ProfileService profileService;
 
     // 자녀 프로필 추가
     @Operation(summary = "자녀 프로필 생성", description = "자녀 프로필을 생성합니다.")
     @PostMapping("/child")
-    public ApiResponse<String> createChildProfile(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                  @Valid @RequestBody ChildProfileRequestDto requestDto){
-        profileService.createChildProfile(userDetails.getUserId(), requestDto);
+    public ApiResponse<String> createChildProfile(@Valid @RequestBody ChildProfileRequestDto requestDto){
+        profileService.createChildProfile(requestDto);
         return ApiResponse.onSuccess("프로필이 성공적으로 생성되었습니다.");
     }
 
     // 회원가입 즉시 프로필 생성 (부모 프로필)
     @Operation(summary = "부모 프로필 생성", description = "회원가입 후 부모 프로필을 생성합니다.")
     @PostMapping("/parent")
-    public ApiResponse<String> createParentProfile(@AuthenticationPrincipal CustomUserDetails userDetails){
-        profileService.createParentProfile(userDetails.getUserId());
+    public ApiResponse<String> createParentProfile(){
+        profileService.createParentProfile();
         return ApiResponse.onSuccess("프로필이 성공적으로 생성되었습니다.");
     }
 
     // 프로필 리스트
     @Operation(summary = "프로필 리스트 조회", description = "사용자의 프로필 목록을 조회합니다.")
     @GetMapping
-    public ApiResponse<ProfileListResponseDto> getProfiles(@AuthenticationPrincipal CustomUserDetails userDetails){
-        ProfileListResponseDto responseDto = profileService.getProfiles(userDetails.getUserId());
+    public ApiResponse<ProfileListResponseDto> getProfiles(){
+        ProfileListResponseDto responseDto = profileService.getProfiles();
         return ApiResponse.onSuccess(responseDto);
     }
 
     // 프로필 접속
     @Operation(summary = "프로필 접속", description = "선택한 프로필에 접속합니다.")
     @PostMapping("/{profileId}")
-    public ApiResponse<ProfileEnterResponseDto> enterProfile(@AuthenticationPrincipal CustomUserDetails userDetails,
-                                                             @PathVariable("profileId") Long profileId){
-        ProfileEnterResponseDto responseDto = profileService.enterProfile(userDetails.getUserId(), profileId);
+    public ApiResponse<ProfileEnterResponseDto> enterProfile(@PathVariable("profileId") Long profileId){
+        ProfileEnterResponseDto responseDto = profileService.enterProfile(profileId);
         return ApiResponse.onSuccess(responseDto);
     }
 
     // 프로필(회원 정보) 조회
     @Operation(summary = "프로필 조회", description = "현재 선택된 프로필의 회원 정보를 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<ProfileInfoResponseDto> getProfileInfo(@AuthenticationPrincipal CustomProfileDetails profileDetails){
-        ProfileInfoResponseDto responseDto = profileService.getProfileInfo(profileDetails.getProfileId());
+    public ApiResponse<ProfileInfoResponseDto> getProfileInfo(){
+        ProfileInfoResponseDto responseDto = profileService.getProfileInfo();
         return ApiResponse.onSuccess(responseDto);
     }
 
     // 프로필 수정
     @Operation(summary = "자녀 프로필 수정", description = "자녀 프로필 정보를 수정합니다.")
     @PatchMapping("/child")
-    public ApiResponse<String> updateChildProfile(@AuthenticationPrincipal CustomProfileDetails profileDetails,
-                                                  @Valid @RequestBody ChildProfileUpdateRequestDto requestDto) {
-        profileService.updateChildProfile(profileDetails.getProfileId(), requestDto);
+    public ApiResponse<String> updateChildProfile(@Valid @RequestBody ChildProfileUpdateRequestDto requestDto) {
+        profileService.updateChildProfile(requestDto);
         return ApiResponse.onSuccess("회원정보가 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "부모 프로필 수정", description = "부모 프로필 정보를 수정합니다.")
     @PatchMapping("/parent")
-    public ApiResponse<String> updateParentProfile(@AuthenticationPrincipal CustomProfileDetails profileDetails,
-                                                   @Valid @RequestBody ParentProfileUpdateRequestDto requestDto) {
-        profileService.updateParentProfile(profileDetails.getProfileId(), requestDto);
+    public ApiResponse<String> updateParentProfile(@Valid @RequestBody ParentProfileUpdateRequestDto requestDto) {
+        profileService.updateParentProfile(requestDto);
         return ApiResponse.onSuccess("회원정보가 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "비밀번호 수정", description = "현재 비밀번호를 확인 후 새로운 비밀번호로 수정합니다.")
     @PatchMapping("/password")
-    public ApiResponse<String> updatePassword(@AuthenticationPrincipal CustomProfileDetails profileDetails,
-                                              @Valid @RequestBody PasswordUpdateRequestDto requestDto) {
-        profileService.updatePassword(profileDetails.getProfileId(), requestDto);
+    public ApiResponse<String> updatePassword(@Valid @RequestBody PasswordUpdateRequestDto requestDto) {
+        profileService.updatePassword(requestDto);
         return ApiResponse.onSuccess("비밀번호가 성공적으로 수정되었습니다.");
     }
 
     // 프로필 삭제
     @Operation(summary = "프로필 삭제", description = "선택한 프로필을 삭제합니다.")
     @DeleteMapping
-    public ApiResponse<String> deleteProfile(@AuthenticationPrincipal CustomProfileDetails profileDetails){
-        profileService.deleteProfile(profileDetails.getProfileId());
+    public ApiResponse<String> deleteProfile(HttpServletRequest request){
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        profileService.deleteProfile(accessToken);
         return ApiResponse.onSuccess("프로필이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/domain/CustomProfileDetails.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/domain/CustomProfileDetails.java
@@ -2,11 +2,52 @@ package everTale.everTale_be.domain.profile.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
 
 @Getter
 @AllArgsConstructor
-public class CustomProfileDetails{
+public class CustomProfileDetails implements UserDetails {
+
     private final Long userId;
     private final Long profileId;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(() -> "ROLE_USER");
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
 }
 

--- a/src/main/java/everTale/everTale_be/domain/profile/domain/Profile.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/domain/Profile.java
@@ -30,6 +30,7 @@ public class Profile extends BaseTimeEntity {
     private String name;
 
     // 자녀용 필드
+    @Column(name = "birth_date")
     private LocalDate birthDate;
     private String institution;
 
@@ -38,7 +39,7 @@ public class Profile extends BaseTimeEntity {
     private String email;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "profile_type", nullable = false)
     private ProfileType profileType;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/everTale/everTale_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/repository/ProfileRepository.java
@@ -2,6 +2,10 @@ package everTale.everTale_be.domain.profile.repository;
 
 import everTale.everTale_be.domain.profile.domain.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -15,4 +19,13 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     // 현재 로그인한 회원의 프로필들 가져오기
     List<Profile> findAllByUserId(Long userId);
+
+    @Modifying
+    @Transactional
+    @Query(value = "UPDATE Profile p SET " +
+            "p.name = '알 수 없음', " +
+            "p.institution = '알 수 없음', " +
+            "p.birth_date = NULL " +
+            "WHERE profile_id = :profileId", nativeQuery = true)
+    void anonymizeProfile(@Param("profileId") Long profileId);
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -1,6 +1,6 @@
 package everTale.everTale_be.domain.profile.service;
 
-import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
+import everTale.everTale_be.auth.jwt.JwtProvider;
 import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.auth.service.TokenAuthService;
 import everTale.everTale_be.domain.profile.domain.Enum.ProfileType;
@@ -11,15 +11,15 @@ import everTale.everTale_be.domain.profile.dto.request.ParentProfileUpdateReques
 import everTale.everTale_be.domain.profile.dto.request.PasswordUpdateRequestDto;
 import everTale.everTale_be.domain.profile.dto.response.*;
 import everTale.everTale_be.domain.profile.repository.ProfileRepository;
+import everTale.everTale_be.domain.profile.util.UserHelper;
 import everTale.everTale_be.domain.user.domain.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
-import io.jsonwebtoken.Claims;
-import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,33 +30,35 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProfileService {
 
-    private final ProfileRepository profileRepository;
     private final UserRepository userRepository;
+    private final ProfileRepository profileRepository;
     private final PasswordEncoder passwordEncoder;
     private final TokenAuthService tokenAuthService;
     private final JwtUtil jwtUtil;
+    private final JwtProvider jwtProvider;
+    private final UserHelper userHelper;
 
-    public void createChildProfile(Long userId, ChildProfileRequestDto requestDto){
-        boolean exists = profileRepository.existsByUserIdAndName(userId, requestDto.getName());
+    public void createChildProfile(ChildProfileRequestDto requestDto){
+        User rootUser = userHelper.getRootUser();
+        boolean exists = profileRepository.existsByUserIdAndName(rootUser.getId(), requestDto.getName());
         if (exists){
             throw new BadRequestHandler(ErrorStatus.ALREADY_EXISTS_PROFILE);
         }
-        User parent = findUser(userId);
-        profileRepository.save(requestDto.toEntity(parent, ProfileType.CHILD));
+        profileRepository.save(requestDto.toEntity(rootUser, ProfileType.CHILD));
     }
 
-    public void createParentProfile(Long userId) {
-        boolean exists = profileRepository.existsByUserIdAndId(userId, 1L);
+    public void createParentProfile() {
+        User rootUser = userHelper.getRootUser();
+        boolean exists = profileRepository.existsByUserIdAndId(rootUser.getId(), 1L);
         if (exists) {
             throw new BadRequestHandler(ErrorStatus.ALREADY_EXISTS_PARENT_PROFILE);
         }
-        User user = findUser(userId);
 
         Profile parentProfile = Profile.builder()
-                .name(user.getUsername())
-                .email(user.getEmail())
-                .phone(user.getPhone())
-                .user(user)
+                .name(rootUser.getUsername())
+                .email(rootUser.getEmail())
+                .phone(rootUser.getPhone())
+                .user(rootUser)
                 .profileType(ProfileType.PARENT)
                 .build();
 
@@ -64,17 +66,17 @@ public class ProfileService {
     }
 
     @Transactional(readOnly = true)
-    public ProfileListResponseDto getProfiles(Long userId){
-        User user = findUser(userId);
-        List<Profile> profiles = profileRepository.findAllByUserId(userId);
+    public ProfileListResponseDto getProfiles(){
+        User rootUser = userHelper.getRootUser();
+        List<Profile> profiles = profileRepository.findAllByUserId(rootUser.getId());
 
         return ProfileListResponseDto.from(profiles);
     }
 
     // 프로필 상세정보 조회
     @Transactional(readOnly = true)
-    public ProfileInfoResponseDto getProfileInfo(Long profileId){
-        Profile profile = findProfile(profileId);
+    public ProfileInfoResponseDto getProfileInfo(){
+        Profile profile = userHelper.getAuthenticatedProfile();
         if (profile.getProfileType() == ProfileType.PARENT) {
             return ParentProfileInfoResponseDto.from(profile);
         } else {
@@ -83,71 +85,63 @@ public class ProfileService {
     }
 
     @Transactional(readOnly = true)
-    public ProfileEnterResponseDto enterProfile(Long userId, Long profileId){
-        Profile profile = findProfile(profileId);
-        if (profile.getUser().getId() != userId) {
+    public ProfileEnterResponseDto enterProfile(Long profileId){
+        User rootUser = userHelper.getRootUser();
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        if (profile.getUser().getId() != rootUser.getId()) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
-        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(profile.getUser(), profileId);
+        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(rootUser.getId(), profileId);
         return ProfileEnterResponseDto.from(profile, newAccessToken);
     }
 
-    public void updateChildProfile(Long profileId, ChildProfileUpdateRequestDto requestDto) {
-        Profile profile = findProfile(profileId);
+    public void updateChildProfile(ChildProfileUpdateRequestDto requestDto) {
+        Profile profile = userHelper.getAuthenticatedProfile();
         profile.updateChild(requestDto);
     }
 
-    public void updateParentProfile(Long profileId, ParentProfileUpdateRequestDto requestDto) {
-        Profile profile = findProfile(profileId);
+    public void updateParentProfile(ParentProfileUpdateRequestDto requestDto) {
+        Profile profile = userHelper.getAuthenticatedProfile();
         profile.updateParent(requestDto);
     }
 
-    public void updatePassword(Long profileId, PasswordUpdateRequestDto requestDto) {
-        User user = userRepository.findByProfiles_Id(profileId)
+    public void updatePassword(PasswordUpdateRequestDto requestDto) {
+        Profile profile = userHelper.getAuthenticatedProfile();
+        User rootUser = userRepository.findByProfiles_Id(profile.getId())
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+
         // 기존 비밀번호 확인
-        if (!passwordEncoder.matches(requestDto.getCurrentPassword(), user.getPassword())) {
+        if (!passwordEncoder.matches(requestDto.getCurrentPassword(), rootUser.getPassword())) {
             throw new UnAuthorizedHandler(ErrorStatus.INVALID_CREDENTIALS);
         }
         // 새 비밀번호와 확인 비밀번호 일치 여부 확인
         if (!requestDto.isPasswordMatch()) {
             throw new BadRequestHandler(ErrorStatus.PASSWORD_MISMATCH);
         }
-        user.changePassword(passwordEncoder.encode(requestDto.getNewPassword()));
+        rootUser.changePassword(passwordEncoder.encode(requestDto.getNewPassword()));
     }
 
     public ProfileEnterResponseDto reissueWithProfile(String refreshToken, Long profileId) {
-        Claims claims = jwtUtil.extractClaims(refreshToken);
-        Long userId = claims.get("userId", Long.class);
+        Long userId = jwtProvider.getUserIdFromToken(refreshToken);
 
         String storedRefreshToken = tokenAuthService.getRefreshToken(userId);
         if (!storedRefreshToken.equals(refreshToken)) {
             throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
         }
 
-        User user = findUser(userId);
-        Profile profile = findProfile(profileId);
-
-        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(user, profileId);
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(userId, profile.getId());
 
         return ProfileEnterResponseDto.from(profile, newAccessToken);
     }
 
     // 프로필 삭제 (회원 탈퇴 X)
-    public void deleteProfile(Long profileId){
-        Profile profile = findProfile(profileId);
-        profileRepository.delete(profile);
-    }
+    public void deleteProfile(String accessToken){
+        Profile profile = userHelper.getAuthenticatedProfile();
 
-    @Transactional(readOnly = true)
-    public Profile findProfile(Long profileId){
-        return profileRepository.findById(profileId)
-                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
-    }
-
-    @Transactional(readOnly = true)
-    public User findUser(Long userId){
-        return userRepository.findById(userId)
-                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+        tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
+        profileRepository.anonymizeProfile(profile.getId());
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/util/UserHelper.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/util/UserHelper.java
@@ -1,0 +1,42 @@
+package everTale.everTale_be.domain.profile.util;
+
+import everTale.everTale_be.auth.jwt.CustomUserDetails;
+import everTale.everTale_be.domain.profile.domain.CustomProfileDetails;
+import everTale.everTale_be.domain.profile.domain.Profile;
+import everTale.everTale_be.domain.profile.repository.ProfileRepository;
+import everTale.everTale_be.domain.user.domain.User;
+import everTale.everTale_be.domain.user.repository.UserRepository;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserHelper {
+
+    private final ProfileRepository profileRepository;
+    private final UserRepository userRepository;
+
+    // 루트 유저용 메서드
+    public User getRootUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        Long userId = userDetails.getUserId();
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+    }
+
+    // 프로필용 메서드
+    public Profile getAuthenticatedProfile() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        CustomProfileDetails profileDetails = (CustomProfileDetails) authentication.getPrincipal();
+
+        Long profileId = profileDetails.getProfileId();
+        return profileRepository.findById(profileId)
+                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+    }
+}

--- a/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
@@ -25,6 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "USER409", "이미 존재하는 이메일입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER401", "이메일 또는 비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER4012", "유효하지 않은 리프레시 토큰입니다."),
+    BLOCKED_TOKEN(HttpStatus.FORBIDDEN, "USER403", "블랙리스트에 있는 토큰입니다. 다시 로그인 해주세요."),
 
     // Profile 관련 에러
     ALREADY_EXISTS_PROFILE(HttpStatus.CONFLICT, "PROFILE409", "중복되는 프로필 이름입니다."),


### PR DESCRIPTION
## 연관 이슈
close #15 

## 📌 개요
- SecurityContextHolder를 직접 참조하지 않고 현재 로그인한 사용자 및 프로필 정보를 가져올 수 있는 `UserHelper` 유틸을 추가했습니다.
- 로그아웃, 회원 탈퇴, 프로필 삭제 시 Access Token을 Redis 블랙리스트에 등록하여 토큰 재사용을 차단하는 기능을 구현했습니다.

## 🔧 작업 내용
- `UserHelper` 유틸 클래스 추가
  - `getRootUser()`: 현재 로그인한 사용자 정보 조회
  - `getAuthenticatedProfile()`: 현재 인증된 프로필 정보 조회
- `JwtUtil.extractAccessToken()` 메서드 추가 (헤더에서 Bearer Token 추출)
- 로그아웃, 탈퇴, 프로필 삭제 시 access token을 Redis 블랙리스트에 등록
- `JwtFilter`에서 access token 블랙리스트 여부 검증 추가
- 블랙리스트 토큰 요청 시 `BLOCKED_TOKEN` 예외 발생 및 JSON 에러 응답 반환

## 📝 논의 사항
- 프론트와 엑세스 토큰 어떻게 관리할지 의논이 필요함.