### PR TITLE
[feature] 스토리/캐릭터 책장 API 구현

### DIFF
--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtFilter.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtFilter.java
@@ -48,6 +48,7 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         } catch (BadRequestHandler e) {
             setErrorResponse(response, e.getErrorReasonHttpStatus().getCode(), e.getErrorReasonHttpStatus().getMessage());
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
         }
     }
 

--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -113,20 +113,20 @@ public class AuthService {
 
     // 로그아웃
     public void logout(String accessToken) {
-        User user = userHelper.getRootUser();
+        Long userId = userHelper.getRootUserId();
         tokenAuthService.validateNotBlackListed(accessToken);
 
         tokenAuthService.addToBlackListForAccessToken(accessToken, "LOGOUT");
-        tokenAuthService.deleteRefreshToken(user.getId());
+        tokenAuthService.deleteRefreshToken(userId);
     }
 
     // 회원 탈퇴
     public void withdraw(String accessToken) {
-        User user = userHelper.getRootUser();
+        Long userId = userHelper.getRootUserId();
         tokenAuthService.validateNotBlackListed(accessToken);
 
         tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
-        tokenAuthService.deleteRefreshToken(user.getId());
-        userRepository.anonymizeUser(user.getId());
+        tokenAuthService.deleteRefreshToken(userId);
+        userRepository.anonymizeUser(userId);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
+++ b/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
@@ -4,6 +4,7 @@ import everTale.everTale_be.domain.character.dto.CharacterCollectionResponseDto;
 import everTale.everTale_be.domain.character.dto.CharacterDetailResponseDto;
 import everTale.everTale_be.domain.character.service.CharacterService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,7 +26,7 @@ public class CharacterController {
     }
 
     @GetMapping("/{characterId}")
-    public ApiResponse<CharacterDetailResponseDto> getCharacterDetails(@PathVariable("characterId") Long characterId){
+    public ApiResponse<CharacterDetailResponseDto> getCharacterDetails(@Parameter(description = "캐릭터 ID") @PathVariable("characterId") Long characterId){
         CharacterDetailResponseDto responseDto = characterService.getCharacterDetail(characterId);
         return ApiResponse.onSuccess(responseDto);
     }

--- a/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
+++ b/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,7 +25,7 @@ public class CharacterController {
 
     @Operation(summary = "내가 만든 스토리의 캐릭터 목록 조회", description = "내가 작성한 스토리에 등장하는 모든 캐릭터를 페이지네이션 형태로 조회합니다.")
     @GetMapping
-    public ApiResponse<CharacterCollectionResponseDto> getMyCharacters(Pageable pageable){
+    public ApiResponse<CharacterCollectionResponseDto> getMyCharacters(@PageableDefault(size = 8) Pageable pageable){
         CharacterCollectionResponseDto responseDto = characterService.getMyCharacters(pageable);
         return ApiResponse.onSuccess(responseDto);
     }

--- a/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
+++ b/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
@@ -1,0 +1,32 @@
+package everTale.everTale_be.domain.character.controller;
+
+import everTale.everTale_be.domain.character.dto.CharacterCollectionResponseDto;
+import everTale.everTale_be.domain.character.dto.CharacterDetailResponseDto;
+import everTale.everTale_be.domain.character.service.CharacterService;
+import everTale.everTale_be.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/characters")
+public class CharacterController {
+
+    private final CharacterService characterService;
+
+    @GetMapping
+    public ApiResponse<CharacterCollectionResponseDto> getMyCharacters(Pageable pageable){
+        CharacterCollectionResponseDto responseDto = characterService.getMyCharacters(pageable);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    @GetMapping("/{characterId}")
+    public ApiResponse<CharacterDetailResponseDto> getCharacterDetails(@PathVariable("characterId") Long characterId){
+        CharacterDetailResponseDto responseDto = characterService.getCharacterDetail(characterId);
+        return ApiResponse.onSuccess(responseDto);
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
+++ b/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
@@ -4,7 +4,9 @@ import everTale.everTale_be.domain.character.dto.CharacterCollectionResponseDto;
 import everTale.everTale_be.domain.character.dto.CharacterDetailResponseDto;
 import everTale.everTale_be.domain.character.service.CharacterService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,16 +17,19 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/characters")
+@Tag(name = "Character", description = "캐릭터 관련 API")
 public class CharacterController {
 
     private final CharacterService characterService;
 
+    @Operation(summary = "내가 만든 스토리의 캐릭터 목록 조회", description = "내가 작성한 스토리에 등장하는 모든 캐릭터를 페이지네이션 형태로 조회합니다.")
     @GetMapping
     public ApiResponse<CharacterCollectionResponseDto> getMyCharacters(Pageable pageable){
         CharacterCollectionResponseDto responseDto = characterService.getMyCharacters(pageable);
         return ApiResponse.onSuccess(responseDto);
     }
 
+    @Operation(summary = "캐릭터 상세 조회", description = "캐릭터 ID를 기반으로 해당 캐릭터의 상세 정보를 조회합니다.")
     @GetMapping("/{characterId}")
     public ApiResponse<CharacterDetailResponseDto> getCharacterDetails(@Parameter(description = "캐릭터 ID") @PathVariable("characterId") Long characterId){
         CharacterDetailResponseDto responseDto = characterService.getCharacterDetail(characterId);

--- a/src/main/java/everTale/everTale_be/domain/character/dto/CharacterCollectionResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/character/dto/CharacterCollectionResponseDto.java
@@ -1,0 +1,27 @@
+package everTale.everTale_be.domain.character.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CharacterCollectionResponseDto {
+
+    private List<CharacterSummary> characterSummaries;
+    private int currentPage;
+    private int totalPage;
+    private long totalCount;
+
+    public static CharacterCollectionResponseDto from(Page<StoryCharacter> characters){
+        return CharacterCollectionResponseDto.builder()
+                .characterSummaries(characters.stream().map(CharacterSummary::from).toList())
+                .currentPage(characters.getNumber())
+                .totalPage(characters.getTotalPages())
+                .totalCount(characters.getTotalElements())
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/character/dto/CharacterCollectionResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/character/dto/CharacterCollectionResponseDto.java
@@ -1,5 +1,6 @@
 package everTale.everTale_be.domain.character.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import everTale.everTale_be.domain.character.entity.StoryCharacter;
@@ -9,11 +10,19 @@ import java.util.List;
 
 @Getter
 @Builder
+@Schema(description = "캐릭터 책장 응답 DTO")
 public class CharacterCollectionResponseDto {
 
+    @Schema(description = "캐릭터 요약 리스트")
     private List<CharacterSummary> characterSummaries;
+
+    @Schema(description = "현재 페이지 번호", example = "0")
     private int currentPage;
+
+    @Schema(description = "전체 페이지 수", example = "5")
     private int totalPage;
+
+    @Schema(description = "전체 캐릭터 수", example = "12")
     private long totalCount;
 
     public static CharacterCollectionResponseDto from(Page<StoryCharacter> characters){

--- a/src/main/java/everTale/everTale_be/domain/character/dto/CharacterDetailResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/character/dto/CharacterDetailResponseDto.java
@@ -1,6 +1,7 @@
 package everTale.everTale_be.domain.character.dto;
 
 import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,12 +10,22 @@ import java.util.stream.Collectors;
 
 @Getter
 @Builder
+@Schema(description = "캐릭터 상세 조회 응답 DTO")
 public class CharacterDetailResponseDto {
 
+    @Schema(description = "캐릭터 이름", example = "글로든")
     private String name;
+
+    @Schema(description = "캐릭터 나이", example = "11")
     private int age;
+
+    @Schema(description = "캐릭터 성별", example = "MALE")
     private String gender;
+
+    @Schema(description = "캐릭터 성격 목록", example = "[\"활발함\", \"외향적\"]")
     private List<String> personalities;
+
+    @Schema(description = "캐릭터가 등장하는 스토리 제목", example = "엘리오")
     private String storyTitle;
 
     public static CharacterDetailResponseDto from(StoryCharacter character){

--- a/src/main/java/everTale/everTale_be/domain/character/dto/CharacterDetailResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/character/dto/CharacterDetailResponseDto.java
@@ -1,0 +1,31 @@
+package everTale.everTale_be.domain.character.dto;
+
+import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class CharacterDetailResponseDto {
+
+    private String name;
+    private int age;
+    private String gender;
+    private List<String> personalities;
+    private String storyTitle;
+
+    public static CharacterDetailResponseDto from(StoryCharacter character){
+        return CharacterDetailResponseDto.builder()
+                .name(character.getName())
+                .age(character.getAge())
+                .gender(String.valueOf(character.getGender()))
+                .personalities(character.getCharacterPersonalities().stream()
+                            .map(characterPersonality -> characterPersonality.getPersonality().getPersonality())
+                            .collect(Collectors.toList()))
+                .storyTitle(character.getStory().getTitle())
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/character/dto/CharacterSummary.java
+++ b/src/main/java/everTale/everTale_be/domain/character/dto/CharacterSummary.java
@@ -1,0 +1,24 @@
+package everTale.everTale_be.domain.character.dto;
+
+import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CharacterSummary {
+
+    private Long characterId;
+    private String name;
+    private String storyTitle;
+    private String imageUrl;
+
+    public static CharacterSummary from(StoryCharacter character){
+        return CharacterSummary.builder()
+                .characterId(character.getId())
+                .name(character.getName())
+                .storyTitle(character.getStory().getTitle())
+                .imageUrl(character.getImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/character/dto/CharacterSummary.java
+++ b/src/main/java/everTale/everTale_be/domain/character/dto/CharacterSummary.java
@@ -1,16 +1,25 @@
 package everTale.everTale_be.domain.character.dto;
 
 import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@Schema(description = "캐릭터 요약 정보")
 public class CharacterSummary {
 
+    @Schema(description = "캐릭터 ID", example = "1")
     private Long characterId;
+
+    @Schema(description = "캐릭터 이름", example = "글로든")
     private String name;
+
+    @Schema(description = "등장하는 스토리 제목", example = "엘리오")
     private String storyTitle;
+
+    @Schema(description = "캐릭터 이미지 URL", example = "https://example.com/image.png")
     private String imageUrl;
 
     public static CharacterSummary from(StoryCharacter character){

--- a/src/main/java/everTale/everTale_be/domain/character/repository/StoryCharacterRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/character/repository/StoryCharacterRepository.java
@@ -1,9 +1,15 @@
 package everTale.everTale_be.domain.character.repository;
 
 import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface StoryCharacterRepository extends JpaRepository<StoryCharacter, Long> {
+    // 프로필 유저의 모든 스토리의 주인공 조회
+    Page<StoryCharacter> findByStoryProfileId(Long profileId, Pageable pageable);
 }

--- a/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
+++ b/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
@@ -1,0 +1,36 @@
+package everTale.everTale_be.domain.character.service;
+
+import everTale.everTale_be.domain.character.dto.CharacterCollectionResponseDto;
+import everTale.everTale_be.domain.character.dto.CharacterDetailResponseDto;
+import everTale.everTale_be.domain.character.entity.StoryCharacter;
+import everTale.everTale_be.domain.character.repository.StoryCharacterRepository;
+import everTale.everTale_be.domain.profile.domain.Profile;
+import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CharacterService {
+
+    private final UserHelper userHelper;
+    private final StoryCharacterRepository characterRepository;
+
+    // 주인공 모음집 조회
+    public CharacterCollectionResponseDto getMyCharacters(Pageable pageable){
+        Profile profile = userHelper.getAuthenticatedProfile();
+        Page<StoryCharacter> characters = characterRepository.findByStoryProfileId(profile.getId(), pageable);
+        return CharacterCollectionResponseDto.from(characters);
+    }
+
+    // 주인공 상제정보 조회
+    public CharacterDetailResponseDto getCharacterDetail(Long characterId){
+        StoryCharacter character = characterRepository.findById(characterId)
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.CHARACTER_NOT_FOUND));
+        return CharacterDetailResponseDto.from(character);
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
+++ b/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
@@ -22,8 +22,8 @@ public class CharacterService {
 
     // 주인공 모음집 조회
     public CharacterCollectionResponseDto getMyCharacters(Pageable pageable){
-        Profile profile = userHelper.getAuthenticatedProfile();
-        Page<StoryCharacter> characters = characterRepository.findByStoryProfileId(profile.getId(), pageable);
+        Long profileId = userHelper.getAuthenticatedProfileId();
+        Page<StoryCharacter> characters = characterRepository.findByStoryProfileId(profileId, pageable);
         return CharacterCollectionResponseDto.from(characters);
     }
 

--- a/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
@@ -9,6 +9,7 @@ import everTale.everTale_be.domain.profile.dto.response.*;
 import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -51,7 +52,7 @@ public class ProfileController {
     // 프로필 접속
     @Operation(summary = "프로필 접속", description = "선택한 프로필에 접속합니다.")
     @PostMapping("/{profileId}")
-    public ApiResponse<ProfileEnterResponseDto> enterProfile(@PathVariable("profileId") Long profileId){
+    public ApiResponse<ProfileEnterResponseDto> enterProfile(@Parameter(description = "프로필 ID") @PathVariable("profileId") Long profileId){
         ProfileEnterResponseDto responseDto = profileService.enterProfile(profileId);
         return ApiResponse.onSuccess(responseDto);
     }

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -67,8 +67,8 @@ public class ProfileService {
 
     @Transactional(readOnly = true)
     public ProfileListResponseDto getProfiles(){
-        User rootUser = userHelper.getRootUser();
-        List<Profile> profiles = profileRepository.findAllByUserId(rootUser.getId());
+        Long userId = userHelper.getRootUserId();
+        List<Profile> profiles = profileRepository.findAllByUserId(userId);
 
         return ProfileListResponseDto.from(profiles);
     }
@@ -86,13 +86,13 @@ public class ProfileService {
 
     @Transactional(readOnly = true)
     public ProfileEnterResponseDto enterProfile(Long profileId){
-        User rootUser = userHelper.getRootUser();
+        Long userId = userHelper.getRootUserId();
         Profile profile = profileRepository.findById(profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
-        if (profile.getUser().getId() != rootUser.getId()) {
+        if (profile.getUser().getId() != userId) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
-        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(rootUser.getId(), profileId);
+        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(userId, profileId);
         return ProfileEnterResponseDto.from(profile, newAccessToken);
     }
 
@@ -107,8 +107,8 @@ public class ProfileService {
     }
 
     public void updatePassword(PasswordUpdateRequestDto requestDto) {
-        Profile profile = userHelper.getAuthenticatedProfile();
-        User rootUser = userRepository.findByProfiles_Id(profile.getId())
+        Long profileId = userHelper.getAuthenticatedProfileId();
+        User rootUser = userRepository.findByProfiles_Id(profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
         // 기존 비밀번호 확인
@@ -139,9 +139,9 @@ public class ProfileService {
 
     // 프로필 삭제 (회원 탈퇴 X)
     public void deleteProfile(String accessToken){
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Long profileId = userHelper.getAuthenticatedProfileId();
 
         tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
-        profileRepository.anonymizeProfile(profile.getId());
+        profileRepository.anonymizeProfile(profileId);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/util/UserHelper.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/util/UserHelper.java
@@ -24,21 +24,44 @@ public class UserHelper {
     // 루트 유저용 메서드
     public User getRootUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
+        }
 
-        Long userId = userDetails.getUserId();
-        return userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+        if (authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            Long userId = userDetails.getUserId();
+            return userRepository.findById(userId)
+                    .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
+        }
+        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_USER_ACCESS);
+    }
+
+    // 루트 유저 ID만 반환하는 메서드
+    public Long getRootUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        if (authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            return userDetails.getUserId();
+        }
+        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_USER_ACCESS);
     }
 
     // 프로필용 메서드
     public Profile getAuthenticatedProfile() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        CustomProfileDetails profileDetails = (CustomProfileDetails) authentication.getPrincipal();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
+        }
 
-        Long profileId = profileDetails.getProfileId();
-        return profileRepository.findById(profileId)
-                .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        if (authentication.getPrincipal() instanceof CustomProfileDetails profileDetails) {
+            Long profileId = profileDetails.getProfileId();
+            return profileRepository.findById(profileId)
+                    .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        }
+        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
     }
 
     // 프로필 ID 반환용 메서드

--- a/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
+++ b/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
@@ -1,6 +1,7 @@
 package everTale.everTale_be.domain.story.controller;
 
 import everTale.everTale_be.domain.story.dto.SceneResponseDTO;
+import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
 import everTale.everTale_be.domain.story.dto.StoryRequestDTO;
 import everTale.everTale_be.domain.story.service.StoryService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
@@ -8,11 +9,10 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-
-import javax.crypto.spec.DESedeKeySpec;
 
 @RestController
 @RequiredArgsConstructor
@@ -128,4 +128,17 @@ public class StoryController {
         return ApiResponse.onSuccess(image);
     }
 
+    @Operation(summary = "전체 스토리 목록 조회", description = "모든 작가들의 스토리를 페이징 형식으로 조회합니다.")
+    @GetMapping
+    public ApiResponse<StoryCollectionResponseDto> getAllStories(Pageable pageable) {
+        StoryCollectionResponseDto responseDto = storyService.getAllStories(pageable);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    @Operation(summary = "내 스토리 목록 조회", description = "현재 접속한 프로필 사용자의 스토리를 페이징 형식으로 조회합니다.")
+    @GetMapping("/my")
+    public ApiResponse<StoryCollectionResponseDto> getMyStories(Pageable pageable) {
+        StoryCollectionResponseDto responseDto = storyService.getMyStories(pageable);
+        return ApiResponse.onSuccess(responseDto);
+    }
 }

--- a/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
+++ b/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
@@ -8,6 +8,7 @@ import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/story")
+@Tag(name = "Story", description = "스토리 관련 API")
 public class StoryController {
 
     private final StoryService storyService;

--- a/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
+++ b/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -132,14 +133,14 @@ public class StoryController {
 
     @Operation(summary = "전체 스토리 목록 조회", description = "모든 작가들의 스토리를 페이징 형식으로 조회합니다.")
     @GetMapping
-    public ApiResponse<StoryCollectionResponseDto> getAllStories(Pageable pageable) {
+    public ApiResponse<StoryCollectionResponseDto> getAllStories(@PageableDefault(size = 8) Pageable pageable) {
         StoryCollectionResponseDto responseDto = storyService.getAllStories(pageable);
         return ApiResponse.onSuccess(responseDto);
     }
 
     @Operation(summary = "내 스토리 목록 조회", description = "현재 접속한 프로필 사용자의 스토리를 페이징 형식으로 조회합니다.")
     @GetMapping("/my")
-    public ApiResponse<StoryCollectionResponseDto> getMyStories(Pageable pageable) {
+    public ApiResponse<StoryCollectionResponseDto> getMyStories(@PageableDefault(size = 8) Pageable pageable) {
         StoryCollectionResponseDto responseDto = storyService.getMyStories(pageable);
         return ApiResponse.onSuccess(responseDto);
     }

--- a/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
+++ b/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
@@ -75,14 +75,14 @@ public class StoryController {
             @PathVariable Long storyId,
             @RequestBody StoryRequestDTO.StoryWorldViewRequestDTO request
     ) {
-        String initStory = storyService.generateInitStory(storyId, request);
+        String initStory = storyService.generateInitScene(storyId, request);
         return ApiResponse.onSuccess(initStory);
     }
 
     @Operation(summary = "다음 줄거리 생성 API", description = "이전 줄거리를 기반으로 다음 줄거리를 생성한다.")
     @PostMapping("/{storyId}/scene/{sceneNum}")
     public ApiResponse<String> createNextStory(@PathVariable Long storyId, @PathVariable int sceneNum) {
-        String nextStory = storyService.generateNextStory(storyId, sceneNum);
+        String nextStory = storyService.generateNextScene(storyId, sceneNum);
         return ApiResponse.onSuccess(nextStory);
     }
 
@@ -100,7 +100,7 @@ public class StoryController {
             @Parameter(description = "장면 번호") @PathVariable int sceneNum,
             @RequestBody StoryRequestDTO.StoryAnswerRequestDTO request
     ) {
-        String nextStory = storyService.generateNextStoryWithAnswer(storyId, sceneNum, request.getAnswer());
+        String nextStory = storyService.generateNextSceneWithAnswer(storyId, sceneNum, request.getAnswer());
         return ApiResponse.onSuccess(nextStory);
     }
     @Operation(summary = "스케치 기반 이미지 생성 API", description = "아이의 스케치 이미지와 줄거리를 기반으로 이미지를 생성합니다.")

--- a/src/main/java/everTale/everTale_be/domain/story/dto/StoryCollectionResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/story/dto/StoryCollectionResponseDto.java
@@ -1,0 +1,36 @@
+package everTale.everTale_be.domain.story.dto;
+
+import everTale.everTale_be.domain.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+@Schema(description = "책장 응답 DTO")
+public class StoryCollectionResponseDto {
+
+    @Schema(description = "스토리 요약 정보 리스트")
+    private List<StorySummary> storySummaries;
+
+    @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
+    private int currentPage;
+
+    @Schema(description = "전체 페이지 수", example = "5")
+    private int totalPage;
+
+    @Schema(description = "전체 스토리 개수", example = "123")
+    private long totalCount;
+
+    public static StoryCollectionResponseDto from(Page<Story> stories){
+        return StoryCollectionResponseDto.builder()
+                .storySummaries(stories.stream().map(StorySummary::from).toList())
+                .currentPage(stories.getNumber())
+                .totalPage(stories.getTotalPages())
+                .totalCount(stories.getTotalElements())
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/story/dto/StoryCollectionResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/story/dto/StoryCollectionResponseDto.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 @Getter
 @Builder
-@Schema(description = "책장 응답 DTO")
+@Schema(description = "스토리 책장 응답 DTO")
 public class StoryCollectionResponseDto {
 
     @Schema(description = "스토리 요약 정보 리스트")

--- a/src/main/java/everTale/everTale_be/domain/story/dto/StorySummary.java
+++ b/src/main/java/everTale/everTale_be/domain/story/dto/StorySummary.java
@@ -1,0 +1,33 @@
+package everTale.everTale_be.domain.story.dto;
+
+import everTale.everTale_be.domain.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "스토리 요약 정보")
+public class StorySummary {
+
+    @Schema(description = "스토리 ID", example = "1")
+    private Long storyId;
+
+    @Schema(description = "대표 이미지 URL", example = "https://example.com/image.jpg")
+    private String imageUrl;
+
+    @Schema(description = "스토리 제목", example = "루나의 모험")
+    private String title;
+
+    @Schema(description = "작가 이름", example = "김이화")
+    private String authorName;
+
+    public static StorySummary from(Story story){
+        return StorySummary.builder()
+                .storyId(story.getId())
+                .imageUrl(story.getImageUrl())
+                .title(story.getTitle())
+                .authorName(story.getProfile().getName())
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/story/entity/Story.java
+++ b/src/main/java/everTale/everTale_be/domain/story/entity/Story.java
@@ -45,7 +45,7 @@ public class Story {
     private List<Scene> storyScenes = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "profile_id", updatable = false, nullable = false)
+    @JoinColumn(name = "author_id", updatable = false, nullable = false)
     private Profile profile;
 
     public void setCharacter(StoryCharacter character) {

--- a/src/main/java/everTale/everTale_be/domain/story/repository/StoryRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/story/repository/StoryRepository.java
@@ -1,7 +1,11 @@
 package everTale.everTale_be.domain.story.repository;
 
 import everTale.everTale_be.domain.story.entity.Story;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoryRepository extends JpaRepository<Story, Long> {
+    // 내가 쓴 스토리 조회
+    Page<Story> findByProfileId(Long profileId, Pageable pageable);
 }

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -261,8 +261,8 @@ public class StoryService {
 
     // 나의 책장
     public StoryCollectionResponseDto getMyStories(Pageable pageable) {
-        Profile profile = userHelper.getAuthenticatedProfile();
-        Page<Story> stories = storyRepository.findByProfileId(profile.getId(), pageable);
+        Long profileId = userHelper.getAuthenticatedProfileId();
+        Page<Story> stories = storyRepository.findByProfileId(profileId, pageable);
         return StoryCollectionResponseDto.from(stories);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -8,6 +8,7 @@ import everTale.everTale_be.domain.character.repository.StoryCharacterRepository
 import everTale.everTale_be.domain.profile.domain.Profile;
 import everTale.everTale_be.domain.profile.util.UserHelper;
 import everTale.everTale_be.domain.story.dto.SceneResponseDTO;
+import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
 import everTale.everTale_be.domain.story.dto.StoryRequestDTO;
 import everTale.everTale_be.domain.story.entity.Scene;
 import everTale.everTale_be.domain.story.entity.Story;
@@ -16,6 +17,8 @@ import everTale.everTale_be.domain.story.repository.StoryRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.domain.story.external.StoryApiClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -248,5 +251,18 @@ public class StoryService {
         Long profileId = userHelper.getAuthenticatedProfileId();
         return storyRepository.findByIdAndProfileId(storyId, profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.STORY_NOT_FOUND));
+    }
+
+    // 모두의 책장
+    public StoryCollectionResponseDto getAllStories(Pageable pageable){
+        Page<Story> stories = storyRepository.findAll(pageable);
+        return StoryCollectionResponseDto.from(stories);
+    }
+
+    // 나의 책장
+    public StoryCollectionResponseDto getMyStories(Pageable pageable) {
+        Profile profile = userHelper.getAuthenticatedProfile();
+        Page<Story> stories = storyRepository.findByProfileId(profile.getId(), pageable);
+        return StoryCollectionResponseDto.from(stories);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -5,7 +5,10 @@ import everTale.everTale_be.domain.character.entity.StoryCharacter;
 import everTale.everTale_be.domain.character.entity.enums.Gender;
 import everTale.everTale_be.domain.character.repository.PersonalityRepository;
 import everTale.everTale_be.domain.character.repository.StoryCharacterRepository;
+import everTale.everTale_be.domain.profile.domain.Profile;
+import everTale.everTale_be.domain.profile.util.UserHelper;
 import everTale.everTale_be.domain.story.dto.SceneResponseDTO;
+import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
 import everTale.everTale_be.domain.story.dto.StoryRequestDTO;
 import everTale.everTale_be.domain.story.entity.Scene;
 import everTale.everTale_be.domain.story.entity.Story;
@@ -14,6 +17,8 @@ import everTale.everTale_be.domain.story.repository.StoryRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.domain.story.external.StoryApiClient;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -31,6 +36,7 @@ public class StoryService {
     private final StoryCharacterRepository storyCharacterRepository;
     private final PersonalityRepository personalityRepository;
     private final StoryApiClient storyApiClient;
+    private final UserHelper userHelper;
 
     // Scene 단일 조회
     @Transactional(readOnly = true)
@@ -251,5 +257,18 @@ public class StoryService {
 
         scene.setImageUrl(imageUrl);
         return imageUrl;
+    }
+
+    // 모두의 책장
+    public StoryCollectionResponseDto getAllStories(Pageable pageable){
+        Page<Story> stories = storyRepository.findAll(pageable);
+        return StoryCollectionResponseDto.from(stories);
+    }
+
+    // 나의 책장
+    public StoryCollectionResponseDto getMyStories(Pageable pageable) {
+        Profile profile = userHelper.getAuthenticatedProfile();
+        Page<Story> stories = storyRepository.findByProfileId(profile.getId(), pageable);
+        return StoryCollectionResponseDto.from(stories);
     }
 }

--- a/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
@@ -25,7 +25,7 @@ public enum ErrorStatus implements BaseErrorCode {
     ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "USER409", "이미 존재하는 이메일입니다."),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER401", "이메일 또는 비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER4012", "유효하지 않은 리프레시 토큰입니다."),
-    BLOCKED_TOKEN(HttpStatus.FORBIDDEN, "USER403", "블랙리스트에 있는 토큰입니다. 다시 로그인 해주세요."),
+    BLOCKED_TOKEN(HttpStatus.BAD_REQUEST, "USER400", "블랙리스트에 있는 토큰입니다. 다시 로그인 해주세요."),
 
     // Profile 관련 에러
     ALREADY_EXISTS_PROFILE(HttpStatus.CONFLICT, "PROFILE409", "중복되는 프로필 이름입니다."),

--- a/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/everTale/everTale_be/global/apiPayload/code/status/ErrorStatus.java
@@ -21,9 +21,10 @@ public enum ErrorStatus implements BaseErrorCode {
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "TOKEN404", "리프레시 토큰이 존재하지 않습니다."),
 
     // User 관련 에러
+    UNAUTHORIZED_USER_ACCESS(HttpStatus.UNAUTHORIZED, "USER401", "해당 유저에 대한 접근이 거부되었습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
     ALREADY_EXISTS_EMAIL(HttpStatus.CONFLICT, "USER409", "이미 존재하는 이메일입니다."),
-    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER401", "이메일 또는 비밀번호가 일치하지 않습니다."),
+    INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "USER4012", "이메일 또는 비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "USER4012", "유효하지 않은 리프레시 토큰입니다."),
     BLOCKED_TOKEN(HttpStatus.BAD_REQUEST, "USER400", "블랙리스트에 있는 토큰입니다. 다시 로그인 해주세요."),
 


### PR DESCRIPTION
## 연관 이슈
close #19 

## 📌 개요
스토리 및 캐릭터 관련 목록/상세 조회 API를 구현했습니다.  
사용자는 자신이 작성한 스토리와 해당 스토리에 등장하는 캐릭터들을 조회할 수 있고, 특정 캐릭터의 상세 정보도 확인할 수 있습니다.

## 🔧 작업 내용

### StoryController
- 모든 사용자의 스토리 조회 API (`GET /api/story`)
<img width="920" height="811" alt="스크린샷 2025-07-11 오후 4 17 44" src="https://github.com/user-attachments/assets/6efcae09-ce95-4849-b467-1d30dab63035" />
- 현재 로그인된 프로필의 스토리 조회 API (`GET /api/stories/my`)
<img width="921" height="766" alt="스크린샷 2025-07-11 오후 4 18 46" src="https://github.com/user-attachments/assets/3df36235-ceef-48f3-a4fe-63978138fa09" />

### CharacterController
- 내가 작성한 스토리에 등장하는 캐릭터 리스트 조회 API (`GET /api/characters`)
<img width="921" height="798" alt="스크린샷 2025-07-11 오후 4 27 02" src="https://github.com/user-attachments/assets/7eab7811-94ab-4dad-82b9-c32ba4b08e03" />
- 캐릭터 상세 조회 API (`GET /api/characters/{characterId}`
<img width="925" height="733" alt="스크린샷 2025-07-11 오후 4 27 33" src="https://github.com/user-attachments/assets/287c1a96-7dc5-45ab-8f67-f8e14cb584c6" />

## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->
- 현재 스토리 관련 API 경로가 단수형(/story)으로 되어있는데, RESTful API 설계 원칙에서는 리소스명을 복수형으로 표현하는 것이 일반적으로 권장되는 컨벤션으로 알고 있어서 `@RequestMapping("/stories")`와 같이 복수형으로 변경하는 것은 어떨지 제안드립니다 ! 😊
---
