### PR TITLE
[refactor] 루트 로그인/프로필 접속 토큰 발급 구조 리팩토링

### DIFF
--- a/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
+++ b/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
@@ -44,16 +44,8 @@ public class AuthController {
     @GetMapping("/naver-login")
     @Operation(summary = "네이버 로그인", description = "네이버 소셜 로그인. OAuth 인가 코드와 state를 통해 토큰을 발급합니다.")
     public ApiResponse<LoginTokenResponseDto> naverLogin(@RequestParam String code,
-                                                            @RequestParam String state) {
+                                                         @RequestParam String state) {
         LoginTokenResponseDto responseDto = authService.naverLogin(code, state);
-        return ApiResponse.onSuccess(responseDto);
-    }
-
-    // 토큰 재발급
-    @PostMapping("/reissue")
-    @Operation(summary = "토큰 재발급", description = "Refresh Token을 통해 Access Token과 Refresh Token을 재발급합니다.")
-    public ApiResponse<LoginTokenResponseDto> reissue(@Valid @RequestBody ReissueRequestDto requestDto){
-        LoginTokenResponseDto responseDto = authService.reissue(requestDto.getRefreshToken());
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/everTale/everTale_be/auth/dto/response/LoginTokenResponseDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/response/LoginTokenResponseDto.java
@@ -1,5 +1,6 @@
 package everTale.everTale_be.auth.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.domain.user.entity.User;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,22 +14,22 @@ public class LoginTokenResponseDto {
 
     @Schema(description = "Access Token", example = "eyJhbGciOiJIUzI1...")
     private String accessToken;
-    @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1...")
-    private String refreshToken;
+
     @Schema(description = "Access Token 만료 시간 (timestamp, ms)", example = "1717654800000")
     private long accessExp;
-    @Schema(description = "Refresh Token 만료 시간 (timestamp, ms)", example = "1718259600000")
-    private long refreshExp;
+
     @Schema(description = "유저 ID", example = "1")
     private Long userId;
 
-    public static LoginTokenResponseDto of(User user, String accessToken, String refreshToken, JwtUtil jwtUtil){
+    @Schema(description = "첫 가입 여부", example = "true")
+    private boolean firstLogin;
+
+    public static LoginTokenResponseDto of(User user, String accessToken, JwtUtil jwtUtil, boolean isFirstLogin) {
         return LoginTokenResponseDto.builder()
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
                 .accessExp(System.currentTimeMillis() + jwtUtil.getAccessTokenExpireTime())
-                .refreshExp(System.currentTimeMillis() + jwtUtil.getRefreshTokenExpireTime())
                 .userId(user.getId())
+                .firstLogin(isFirstLogin)
                 .build();
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
@@ -1,6 +1,7 @@
 package everTale.everTale_be.auth.jwt;
 
-import everTale.everTale_be.domain.profile.entity.CustomProfileDetails;
+import everTale.everTale_be.auth.util.CustomUserDetails;
+import everTale.everTale_be.domain.profile.util.CustomProfileDetails;
 import everTale.everTale_be.domain.user.entity.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtUtil.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtUtil.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
 import java.util.Date;
+import java.util.List;
 
 @Slf4j
 @Component
@@ -35,33 +36,37 @@ public class JwtUtil {
 
         return Jwts.builder()
                 .claim("userId", user.getId())
+                .claim("scope", List.of("account"))
                 .issuedAt(generated)
                 .expiration(accessTokenExpiredAt)
                 .signWith(secretKey)
                 .compact();
     }
 
-    // 프로필 선택 후, 프로필 ID가 추가된 JWT 토큰 생성
+    // 프로필 기반 JWT 토큰 생성
     public String generateAccessTokenWithProfile(Long userId, Long profileId) {
         Date generated = new Date(System.currentTimeMillis());
         Date accessTokenExpiredAt = new Date(generated.getTime() + ACCESS_TOKEN_EXPIRE_TIME);
 
         return Jwts.builder()
-                .claim("userId", userId)  // userId
-                .claim("profileId", profileId)  // profileId 추가
+                .claim("userId", userId)
+                .claim("profileId", profileId)
+                .claim("scope", List.of("profile"))
                 .issuedAt(generated)
                 .expiration(accessTokenExpiredAt)
                 .signWith(secretKey)
                 .compact();
     }
 
-    // JWT refresh token 생성
-    public String generateRefreshToken(User user) {
+    // 프로필 기반 JWT refresh token 생성
+    public String generateRefreshTokenWithProfile(Long userId, Long profileId) {
         Date generated = new Date(System.currentTimeMillis());
         Date refreshTokenExpiredAt = new Date(generated.getTime() + REFRESH_TOKEN_EXPIRE_TIME);
 
         return Jwts.builder()
-                .claim("userId", user.getId())
+                .claim("userId", userId)
+                .claim("profileId", profileId)
+                .claim("scope", List.of("profile"))
                 .issuedAt(generated)
                 .expiration(refreshTokenExpiredAt)
                 .signWith(secretKey)

--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -6,7 +6,7 @@ import everTale.everTale_be.auth.dto.response.LoginTokenResponseDto;
 import everTale.everTale_be.auth.dto.response.UserInfoResponseDto;
 import everTale.everTale_be.auth.jwt.JwtProvider;
 import everTale.everTale_be.auth.jwt.JwtUtil;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.auth.util.UserHelper;
 import everTale.everTale_be.domain.user.entity.Enum.LoginProvider;
 import everTale.everTale_be.domain.user.entity.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
@@ -17,6 +17,8 @@ import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHand
 import org.springframework.security.crypto.password.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -57,30 +59,30 @@ public class AuthService {
         }
 
         String accessToken = jwtUtil.generateAccessToken(user);
-        String refreshToken = jwtUtil.generateRefreshToken(user);
 
-        tokenAuthService.saveRefreshToken(user.getId(), refreshToken);
-
-        return LoginTokenResponseDto.of(user, accessToken, refreshToken, jwtUtil);
+        return LoginTokenResponseDto.of(user, accessToken, jwtUtil, false);
     }
 
     // 네이버 로그인
     public LoginTokenResponseDto naverLogin(String code, String state) {
         String naverAccessToken = naverService.getNaverAccessToken(code, state);
         UserInfoResponseDto userInfo = naverService.getNaverUser(naverAccessToken);
-        User user = findOrCreateUserForNaver(userInfo);
+
+        Optional<User> findUser = userRepository.findByEmailAndLoginProvider(userInfo.getResponse().getEmail(), LoginProvider.NAVER);
+
+        final boolean isFirstLogin;
+        final User user;
+
+        if (findUser.isPresent()) {
+            user = findUser.get();
+            isFirstLogin = false;
+        } else {
+            user = createUserForNaver(userInfo);
+            isFirstLogin = true;
+        }
 
         String accessToken = jwtUtil.generateAccessToken(user);
-        String refreshToken = jwtUtil.generateRefreshToken(user);
-
-        tokenAuthService.saveRefreshToken(user.getId(), refreshToken);
-
-        return LoginTokenResponseDto.of(user, accessToken, refreshToken, jwtUtil);
-    }
-
-    public User findOrCreateUserForNaver(UserInfoResponseDto responseDto){
-        return userRepository.findByEmailAndLoginProvider(responseDto.getResponse().getEmail(), LoginProvider.NAVER)
-                .orElseGet(()-> createUserForNaver(responseDto));
+        return LoginTokenResponseDto.of(user, accessToken, jwtUtil, isFirstLogin);
     }
 
     public User createUserForNaver(UserInfoResponseDto responseDto){
@@ -92,23 +94,6 @@ public class AuthService {
                 .loginProvider(LoginProvider.NAVER)
                 .build();
         return userRepository.save(user);
-    }
-
-    // 토큰 재발급
-    public LoginTokenResponseDto reissue(String refreshToken){
-        Long userId = jwtProvider.getUserIdFromToken(refreshToken);
-        tokenAuthService.validateRefreshToken(userId, refreshToken);
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
-
-        tokenAuthService.deleteRefreshToken(userId);
-
-        String newAccessToken = jwtUtil.generateAccessToken(user);
-        String newRefreshToken = jwtUtil.generateRefreshToken(user);
-        tokenAuthService.saveRefreshToken(userId, newRefreshToken);
-
-        return LoginTokenResponseDto.of(user, newAccessToken, newRefreshToken, jwtUtil);
     }
 
     // 로그아웃

--- a/src/main/java/everTale/everTale_be/auth/service/TokenAuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/TokenAuthService.java
@@ -20,17 +20,17 @@ public class TokenAuthService {
     private static final String BLACKLIST_PREFIX = "blacklist:";
 
     // token 저장
-    public void saveRefreshToken(Long userId, String refreshToken) {
+    public void saveRefreshToken(Long profileId, String refreshToken) {
         redisTemplate.opsForValue().set(
-                PREFIX + userId,   // Key
+                PREFIX + profileId, // Key
                 refreshToken,           // Value
                 7, TimeUnit.DAYS        // 유효기간
         );
     }
 
     // token 조회
-    public String getRefreshToken(Long userId) {
-        String token = redisTemplate.opsForValue().get(PREFIX + userId);
+    public String getRefreshToken(Long profileId) {
+        String token = redisTemplate.opsForValue().get(PREFIX + profileId);
         if (token == null) {
             throw new UnAuthorizedHandler(ErrorStatus.NOT_FOUND_REFRESH_TOKEN);
         }
@@ -38,13 +38,13 @@ public class TokenAuthService {
     }
 
     // token 삭제
-    public void deleteRefreshToken(Long userId) {
-        redisTemplate.delete(PREFIX + userId);
+    public void deleteRefreshToken(Long profileId) {
+        redisTemplate.delete(PREFIX + profileId);
     }
 
     // token 존재 여부
-    public void validateRefreshToken(Long userId, String refreshToken) {
-        String storedRefreshToken = getRefreshToken(userId);
+    public void validateRefreshToken(Long profileId, String refreshToken) {
+        String storedRefreshToken = getRefreshToken(profileId);
         if (!storedRefreshToken.equals(refreshToken)) {
             throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
         }

--- a/src/main/java/everTale/everTale_be/auth/util/CustomUserDetails.java
+++ b/src/main/java/everTale/everTale_be/auth/util/CustomUserDetails.java
@@ -1,19 +1,25 @@
-package everTale.everTale_be.domain.profile.entity;
+package everTale.everTale_be.auth.util;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import everTale.everTale_be.domain.user.entity.User;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import lombok.Getter;
 
 import java.util.Collection;
 import java.util.Collections;
 
 @Getter
-@AllArgsConstructor
-public class CustomProfileDetails implements UserDetails {
+public class CustomUserDetails implements UserDetails {
 
     private final Long userId;
-    private final Long profileId;
+    private final String email;
+    private final String username;
+
+    public CustomUserDetails(User user) {
+        this.userId = user.getId();
+        this.email = user.getEmail();
+        this.username = user.getUsername();
+    }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -22,32 +28,31 @@ public class CustomProfileDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null;
+        return null; // JWT에서는 비밀번호 필요 없음
     }
 
     @Override
     public String getUsername() {
-        return null;
+        return username;
     }
 
     @Override
     public boolean isAccountNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return false;
+        return true;
     }
 
     @Override
     public boolean isEnabled() {
-        return false;
+        return true;
     }
 }
-

--- a/src/main/java/everTale/everTale_be/auth/util/UserHelper.java
+++ b/src/main/java/everTale/everTale_be/auth/util/UserHelper.java
@@ -1,9 +1,5 @@
-package everTale.everTale_be.domain.profile.util;
+package everTale.everTale_be.auth.util;
 
-import everTale.everTale_be.auth.jwt.CustomUserDetails;
-import everTale.everTale_be.domain.profile.entity.CustomProfileDetails;
-import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.repository.ProfileRepository;
 import everTale.everTale_be.domain.user.entity.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
@@ -18,7 +14,6 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class UserHelper {
 
-    private final ProfileRepository profileRepository;
     private final UserRepository userRepository;
 
     // 루트 유저용 메서드
@@ -47,33 +42,5 @@ public class UserHelper {
             return userDetails.getUserId();
         }
         throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_USER_ACCESS);
-    }
-
-    // 프로필용 메서드
-    public Profile getAuthenticatedProfile() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
-        }
-
-        if (authentication.getPrincipal() instanceof CustomProfileDetails profileDetails) {
-            Long profileId = profileDetails.getProfileId();
-            return profileRepository.findById(profileId)
-                    .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
-        }
-        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
-    }
-
-    // 프로필 ID 반환용 메서드
-    public Long getAuthenticatedProfileId() {
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || !authentication.isAuthenticated()) {
-            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
-        }
-
-        if (authentication.getPrincipal() instanceof CustomProfileDetails profileDetails) {
-            return profileDetails.getProfileId();
-        }
-        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
+++ b/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
@@ -4,7 +4,7 @@ import everTale.everTale_be.domain.character.dto.CharacterCollectionResponseDto;
 import everTale.everTale_be.domain.character.dto.CharacterDetailResponseDto;
 import everTale.everTale_be.domain.character.entity.StoryCharacter;
 import everTale.everTale_be.domain.character.repository.StoryCharacterRepository;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class CharacterService {
 
-    private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
     private final StoryCharacterRepository characterRepository;
 
     // 주인공 모음집 조회
     public CharacterCollectionResponseDto getMyCharacters(Pageable pageable){
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         Page<StoryCharacter> characters = characterRepository.findByStoryProfileId(profileId, pageable);
         return CharacterCollectionResponseDto.from(characters);
     }

--- a/src/main/java/everTale/everTale_be/domain/easterEggLetter/service/EasterEggLetterService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEggLetter/service/EasterEggLetterService.java
@@ -5,7 +5,7 @@ import everTale.everTale_be.domain.easterEggLetter.dto.EasterEggLetterResponseDT
 import everTale.everTale_be.domain.easterEggLetter.entity.EasterEggLetter;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.entity.Story;
 import everTale.everTale_be.domain.story.repository.StoryRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
@@ -24,7 +24,7 @@ import java.time.LocalDateTime;
 public class EasterEggLetterService {
 
     private final StoryRepository storyRepository;
-    private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
 
     // 이스터에그 편지 생성
     @Transactional
@@ -48,7 +48,7 @@ public class EasterEggLetterService {
     // 이스터에그 편지 조회
     @Transactional(readOnly = true)
     public EasterEggLetterResponseDTO getEasterEggLetterFor(Long storyId) {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         ProfileType role = profile.getProfileType();
 
         // 스토리 조회
@@ -101,7 +101,7 @@ public class EasterEggLetterService {
 
     private Story getStoryForParent(Long storyId) {
         // 부모 권한 검증
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         if (profile.getProfileType() != ProfileType.PARENT) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }

--- a/src/main/java/everTale/everTale_be/domain/easterEggVoice/service/EasterEggVoiceService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEggVoice/service/EasterEggVoiceService.java
@@ -6,7 +6,7 @@ import everTale.everTale_be.domain.easterEggVoice.entity.EasterEggVoice;
 import everTale.everTale_be.domain.easterEggVoice.repository.EasterEggVoiceRepository;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.entity.Scene;
 import everTale.everTale_be.domain.story.repository.SceneRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
@@ -24,7 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 public class EasterEggVoiceService {
 
-    private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
     private final S3Manager s3Manager;
     private final SceneRepository sceneRepository;
     private final EasterEggVoiceRepository easterEggVoiceRepository;
@@ -89,7 +89,7 @@ public class EasterEggVoiceService {
 
     @Transactional(readOnly = true)
     private void validateParent() {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         if (profile.getProfileType() != ProfileType.PARENT) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }

--- a/src/main/java/everTale/everTale_be/domain/profile/dto/response/ProfileEnterResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/dto/response/ProfileEnterResponseDto.java
@@ -1,5 +1,6 @@
 package everTale.everTale_be.domain.profile.dto.response;
 
+import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -17,13 +18,26 @@ public class ProfileEnterResponseDto {
     @Schema(description = "프로필 타입", example = "PARENT")
     private ProfileType profileType;
 
+    @Schema(description = "프로필 Access Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
     private String accessToken;
 
-    public static ProfileEnterResponseDto from(Profile profile, String accessToken){
+    @Schema(description = "프로필 Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...")
+    private String refreshToken;
+
+    @Schema(description = "Access Token 만료 시간(ms)", example = "1755015103057")
+    private long accessExp;
+
+    @Schema(description = "Refresh Token 만료 시간(ms)", example = "1755015103057")
+    private long refreshExp;
+
+    public static ProfileEnterResponseDto from(Profile profile, String accessToken, String refreshToken, JwtUtil jwtUtil){
         return ProfileEnterResponseDto.builder()
                 .profileId(profile.getId())
                 .profileType(profile.getProfileType())
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .accessExp(jwtUtil.getAccessTokenExpireTime())
+                .refreshExp(jwtUtil.getRefreshTokenExpireTime())
                 .build();
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -3,6 +3,7 @@ package everTale.everTale_be.domain.profile.service;
 import everTale.everTale_be.auth.jwt.JwtProvider;
 import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.auth.service.TokenAuthService;
+import everTale.everTale_be.auth.util.UserHelper;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import everTale.everTale_be.domain.profile.dto.request.ChildProfileRequestDto;
@@ -11,13 +12,14 @@ import everTale.everTale_be.domain.profile.dto.request.ParentProfileUpdateReques
 import everTale.everTale_be.domain.profile.dto.request.PasswordUpdateRequestDto;
 import everTale.everTale_be.domain.profile.dto.response.*;
 import everTale.everTale_be.domain.profile.repository.ProfileRepository;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.user.entity.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
+import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +38,7 @@ public class ProfileService {
     private final TokenAuthService tokenAuthService;
     private final JwtUtil jwtUtil;
     private final JwtProvider jwtProvider;
+    private final ProfileHelper profileHelper;
     private final UserHelper userHelper;
 
     public void createChildProfile(ChildProfileRequestDto requestDto){
@@ -76,7 +79,7 @@ public class ProfileService {
     // 프로필 상세정보 조회
     @Transactional(readOnly = true)
     public ProfileInfoResponseDto getProfileInfo(){
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         if (profile.getProfileType() == ProfileType.PARENT) {
             return ParentProfileInfoResponseDto.from(profile);
         } else {
@@ -92,22 +95,25 @@ public class ProfileService {
         if (profile.getUser().getId() != userId) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
-        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(userId, profileId);
-        return ProfileEnterResponseDto.from(profile, newAccessToken);
+        String accessToken = jwtUtil.generateAccessTokenWithProfile(userId, profileId);
+        String refreshToken = jwtUtil.generateRefreshTokenWithProfile(userId, profileId);
+        tokenAuthService.saveRefreshToken(profileId, refreshToken);
+
+        return ProfileEnterResponseDto.from(profile, accessToken, refreshToken, jwtUtil);
     }
 
     public void updateChildProfile(ChildProfileUpdateRequestDto requestDto) {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         profile.updateChild(requestDto);
     }
 
     public void updateParentProfile(ParentProfileUpdateRequestDto requestDto) {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         profile.updateParent(requestDto);
     }
 
     public void updatePassword(PasswordUpdateRequestDto requestDto) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         User rootUser = userRepository.findByProfiles_Id(profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_USER));
 
@@ -133,13 +139,15 @@ public class ProfileService {
         Profile profile = profileRepository.findById(profileId)
                 .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
         String newAccessToken = jwtUtil.generateAccessTokenWithProfile(userId, profile.getId());
+        String newRefreshToken = jwtUtil.generateRefreshTokenWithProfile(userId, profile.getId());
+        tokenAuthService.saveRefreshToken(profileId, newRefreshToken);
 
-        return ProfileEnterResponseDto.from(profile, newAccessToken);
+        return ProfileEnterResponseDto.from(profile, newAccessToken, newRefreshToken, jwtUtil);
     }
 
     // 프로필 삭제 (회원 탈퇴 X)
     public void deleteProfile(String accessToken){
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
 
         tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
         profileRepository.anonymizeProfile(profileId);

--- a/src/main/java/everTale/everTale_be/domain/profile/util/CustomProfileDetails.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/util/CustomProfileDetails.java
@@ -1,25 +1,19 @@
-package everTale.everTale_be.auth.jwt;
+package everTale.everTale_be.domain.profile.util;
 
-import everTale.everTale_be.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
-import lombok.Getter;
 
 import java.util.Collection;
 import java.util.Collections;
 
 @Getter
-public class CustomUserDetails implements UserDetails {
+@AllArgsConstructor
+public class CustomProfileDetails implements UserDetails {
 
     private final Long userId;
-    private final String email;
-    private final String username;
-
-    public CustomUserDetails(User user) {
-        this.userId = user.getId();
-        this.email = user.getEmail();
-        this.username = user.getUsername();
-    }
+    private final Long profileId;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -28,31 +22,32 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public String getPassword() {
-        return null; // JWT에서는 비밀번호 필요 없음
+        return null;
     }
 
     @Override
     public String getUsername() {
-        return username;
+        return null;
     }
 
     @Override
     public boolean isAccountNonExpired() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean isCredentialsNonExpired() {
-        return true;
+        return false;
     }
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return false;
     }
 }
+

--- a/src/main/java/everTale/everTale_be/domain/profile/util/ProfileHelper.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/util/ProfileHelper.java
@@ -1,0 +1,46 @@
+package everTale.everTale_be.domain.profile.util;
+
+import everTale.everTale_be.domain.profile.entity.Profile;
+import everTale.everTale_be.domain.profile.repository.ProfileRepository;
+import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
+import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
+import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProfileHelper {
+
+    private final ProfileRepository profileRepository;
+
+    // 프로필용 메서드
+    public Profile getAuthenticatedProfile() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        if (authentication.getPrincipal() instanceof CustomProfileDetails profileDetails) {
+            Long profileId = profileDetails.getProfileId();
+            return profileRepository.findById(profileId)
+                    .orElseThrow(() -> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        }
+        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+    }
+
+    // 프로필 ID 반환용 메서드
+    public Long getAuthenticatedProfileId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new UnAuthorizedHandler(ErrorStatus._UNAUTHORIZED);
+        }
+
+        if (authentication.getPrincipal() instanceof CustomProfileDetails profileDetails) {
+            return profileDetails.getProfileId();
+        }
+        throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/quiz/service/QuizService.java
+++ b/src/main/java/everTale/everTale_be/domain/quiz/service/QuizService.java
@@ -1,7 +1,7 @@
 package everTale.everTale_be.domain.quiz.service;
 
 import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.quiz.dto.QuizResponseDTO;
 import everTale.everTale_be.domain.quiz.entity.Quiz;
 import everTale.everTale_be.domain.quiz.entity.enums.Answer;
@@ -26,11 +26,11 @@ public class QuizService {
     private final SceneRepository sceneRepository;
     private final QuizRepository quizRepository;
     private final QuizApiClient quizApiClient;
-    private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
 
     @Transactional
     public QuizResponseDTO.QuizGenerateResponseDTO generateQuizForRandomScene(Long storyId) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
 
         List<Scene> scenes = sceneRepository.findAllByStoryIdAndStoryProfileIdAndQuizIsNull(storyId, profileId);
         if (scenes.isEmpty()) {
@@ -58,7 +58,7 @@ public class QuizService {
     // quiz 조회
     @Transactional(readOnly = true)
     public List<QuizResponseDTO.QuizGetResponseDTO> getAllQuizzesByStoryId(Long storyId) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         List<Quiz> quizzes = quizRepository.findAllByScene_Story_IdAndScene_Story_Profile_Id(storyId, profileId);
 
         return quizzes.stream()
@@ -69,14 +69,14 @@ public class QuizService {
     // quiz 삭제
     @Transactional
     public void deleteAllQuizzesByStoryId(Long storyId) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         quizRepository.deleteByStoryIdAndProfileId(storyId, profileId);
     }
 
     // quiz 정답
     @Transactional
     public QuizResponseDTO.QuizAnswerResponseDTO submitQuizAnswer(Long quizId, int selectedAnswer) {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.QUIZ_NOT_FOUND));
 
@@ -97,7 +97,7 @@ public class QuizService {
     // 퀴즈 결과 요약 및 칭호 확인
     @Transactional(readOnly = true)
     public QuizResponseDTO.QuizTitleResponseDTO getQuizzesSummary() {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         return QuizResponseDTO.QuizTitleResponseDTO.builder()
                 .correctAnswerCount(profile.getQuizSolvedCount())
                 .badge(profile.getBadge().getBadge())

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -6,7 +6,7 @@ import everTale.everTale_be.domain.character.entity.enums.Gender;
 import everTale.everTale_be.domain.character.repository.PersonalityRepository;
 import everTale.everTale_be.domain.character.repository.StoryCharacterRepository;
 import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.dto.SceneResponseDTO;
 import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
 import everTale.everTale_be.domain.story.dto.StoryRequestDTO;
@@ -36,7 +36,7 @@ public class StoryService {
     private final StoryCharacterRepository storyCharacterRepository;
     private final PersonalityRepository personalityRepository;
     private final StoryApiClient storyApiClient;
-    private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
 
     // Scene 단일 조회
     @Transactional(readOnly = true)
@@ -64,7 +64,7 @@ public class StoryService {
     // 스토리 생성
     @Transactional
     public Long createEmptyStory() {
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         Story story = Story.builder()
                         .profile(profile)
                         .build();
@@ -243,12 +243,12 @@ public class StoryService {
     }
 
     private Scene findScene(Long storyId, int sceneNum){
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         return sceneRepository.findByStoryIdAndPageAndStoryProfileId(storyId, sceneNum, profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.SCENE_NOT_FOUND));
     }
     private Story findStory(Long storyId) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         return storyRepository.findByIdAndProfileId(storyId, profileId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.STORY_NOT_FOUND));
     }
@@ -261,7 +261,7 @@ public class StoryService {
 
     // 나의 책장
     public StoryCollectionResponseDto getMyStories(Pageable pageable) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         Page<Story> stories = storyRepository.findByProfileId(profileId, pageable);
         return StoryCollectionResponseDto.from(stories);
     }

--- a/src/main/java/everTale/everTale_be/domain/voice/service/VoiceService.java
+++ b/src/main/java/everTale/everTale_be/domain/voice/service/VoiceService.java
@@ -2,7 +2,7 @@ package everTale.everTale_be.domain.voice.service;
 
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.util.UserHelper;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.user.entity.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
 import everTale.everTale_be.domain.voice.entity.Voice;
@@ -26,13 +26,13 @@ import java.util.List;
 @RequiredArgsConstructor
 public class VoiceService {
 
-    private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
     private final UserRepository userRepository;
     private final VoiceRepository voiceRepository;
     private final VoiceApiClient voiceApiClient;
 
     public VoiceListResponseDto getVoicesOfRootUserForProfile() {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         User rootUser = findRootUserByProfile(profileId);
 
         List<Voice> voices = voiceRepository.findAllByUserId(rootUser.getId());
@@ -41,7 +41,7 @@ public class VoiceService {
 
     public void registerUserVoice(MultipartFile file) {
         validateParent();
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         User rootUser = findRootUserByProfile(profileId);
 
         String voiceName = extractNameWithoutExtension(file.getOriginalFilename());
@@ -73,7 +73,7 @@ public class VoiceService {
 
     public void deleteVoice(Long voiceId){
         validateParent();
-        Long profileId = userHelper.getAuthenticatedProfileId();
+        Long profileId = profileHelper.getAuthenticatedProfileId();
         User rootUser = findRootUserByProfile(profileId);
         Voice voice = findVoice(voiceId);
 
@@ -97,7 +97,7 @@ public class VoiceService {
     }
 
     private void validateParent(){
-        Profile profile = userHelper.getAuthenticatedProfile();
+        Profile profile = profileHelper.getAuthenticatedProfile();
         if (profile.getProfileType() != ProfileType.PARENT) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }


### PR DESCRIPTION
## 연관 이슈
close #33 

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
루트 로그인 시 Refresh Token 발급·저장을 제거하고 Access Token만 발급하도록 변경하rh, 프로필 단위의 세션 유지로 리팩토링하였습니다.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- 로그인 시, access token만 발급받도록 수정 & 기존의 존재하는 유저인지 알려주는 필드(`firstLogin`) 추가
  - 일반 로그인
  <img width="925" height="595" alt="스크린샷 2025-08-13 오전 12 13 42" src="https://github.com/user-attachments/assets/4d1e019c-c583-47f0-add1-7181fd085695" />
  - 네이버 로그인
  <img width="1467" height="916" alt="스크린샷 2025-08-13 오전 12 14 13" src="https://github.com/user-attachments/assets/e420ffe2-8bbe-477f-a44c-cb082bf3b57c" />
- 프로필 접속 시, access token, refresh token 발급받도록 수정
<img width="913" height="773" alt="스크린샷 2025-08-13 오전 12 52 39" src="https://github.com/user-attachments/assets/3c0f933a-8fa3-44b3-b112-e1c63f786bdf" />

## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->

---
