### PR TITLE
[refactor] 부모 프로필과 아이 프로필의 스토리 조회하는 api 통일

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
+++ b/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
@@ -138,10 +138,11 @@ public class StoryController {
         return ApiResponse.onSuccess(responseDto);
     }
 
-    @Operation(summary = "내 스토리 목록 조회", description = "현재 접속한 프로필 사용자의 스토리를 페이징 형식으로 조회합니다.")
-    @GetMapping("/my")
-    public ApiResponse<StoryCollectionResponseDto> getMyStories(@PageableDefault(size = 8) Pageable pageable) {
-        StoryCollectionResponseDto responseDto = storyService.getMyStories(pageable);
+    @Operation(summary = "프로필 사용자의 스토리 목록 조회", description = "현재 접속한 프로필 사용자의 스토리를 페이징 형식으로 조회합니다.")
+    @GetMapping("/{profileId}")
+    public ApiResponse<StoryCollectionResponseDto> getMyStories(@Parameter(description = "프로필 ID") @PathVariable Long profileId,
+                                                                @PageableDefault(size = 8) Pageable pageable) {
+        StoryCollectionResponseDto responseDto = storyService.getStories(profileId, pageable);
         return ApiResponse.onSuccess(responseDto);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -5,7 +5,9 @@ import everTale.everTale_be.domain.character.entity.StoryCharacter;
 import everTale.everTale_be.domain.character.entity.enums.Gender;
 import everTale.everTale_be.domain.character.repository.PersonalityRepository;
 import everTale.everTale_be.domain.character.repository.StoryCharacterRepository;
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
+import everTale.everTale_be.domain.profile.repository.ProfileRepository;
 import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.dto.SceneResponseDTO;
 import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
@@ -17,6 +19,7 @@ import everTale.everTale_be.domain.story.repository.StoryRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.domain.story.external.StoryApiClient;
+import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +38,7 @@ public class StoryService {
     private final StoryRepository storyRepository;
     private final StoryCharacterRepository storyCharacterRepository;
     private final PersonalityRepository personalityRepository;
+    private final ProfileRepository profileRepository;
     private final StoryApiClient storyApiClient;
     private final ProfileHelper profileHelper;
 
@@ -261,6 +265,19 @@ public class StoryService {
 
     // 나의 책장
     public StoryCollectionResponseDto getStories(Long profileId, Pageable pageable) {
+        Profile profile = profileHelper.getAuthenticatedProfile();
+
+        if (profile.getProfileType()== ProfileType.CHILD) {
+            if (!profile.getId().equals(profileId)) {
+                throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+            }
+        } else {
+            boolean isMyChild = profileRepository.existsByUserIdAndId(profile.getId(), profileId);
+            if (!isMyChild) {
+                throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+            }
+        }
+
         Page<Story> stories = storyRepository.findByProfileId(profileId, pageable);
         return StoryCollectionResponseDto.from(stories);
     }

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -260,8 +260,7 @@ public class StoryService {
     }
 
     // 나의 책장
-    public StoryCollectionResponseDto getMyStories(Pageable pageable) {
-        Long profileId = userHelper.getAuthenticatedProfileId();
+    public StoryCollectionResponseDto getStories(Long profileId, Pageable pageable) {
         Page<Story> stories = storyRepository.findByProfileId(profileId, pageable);
         return StoryCollectionResponseDto.from(stories);
     }


### PR DESCRIPTION
## 연관 이슈
close #35 

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
부모 프로필과 아이 프로필의 스토리 조회하는 api 통일하였습니다.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
코드 상의 수정이라 응답 dto 관련해서는 변경사항이 없습니다.

## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->

---
