### PR TITLE
[refactor] easterEggLetter 오픈 시간 형식 및 텍스트 제한 리팩토링

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/easterEggLetter/dto/EasterEggLetterRequestDTO.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEggLetter/dto/EasterEggLetterRequestDTO.java
@@ -1,13 +1,10 @@
 package everTale.everTale_be.domain.easterEggLetter.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public class EasterEggLetterRequestDTO {
     @Getter
@@ -21,6 +18,7 @@ public class EasterEggLetterRequestDTO {
                 example = "토토로야, 항상 널 응원하고 있어! 너의 모험이 즐겁고 안전하길 바래. 사랑해!"
         )
         @NotBlank(message = "편지 내용은 비어 있을 수 없습니다.")
+        @Size(max=300, message="편지 내용은 300자를 넘을 수 없습니다.")
         private String content;
 
         @Schema(
@@ -32,11 +30,11 @@ public class EasterEggLetterRequestDTO {
         private int imageNum;
 
         @Schema(
-                description = "편지를 열 수 있는 시간 (ISO 8601 형식)",
-                example = "2025-07-01T12:00:00"
+                description = "편지를 열 수 있는 시간 (yyyy-MM-dd)",
+                example = "2025-07-01"
         )
         @NotNull(message = "편지를 열 수 있는 시간은 반드시 지정해야 합니다.")
-        private LocalDateTime availableAt;
+        private LocalDate availableAt;
     }
 
     @Getter
@@ -60,10 +58,10 @@ public class EasterEggLetterRequestDTO {
         private int imageNum;
 
         @Schema(
-                description = "편지를 열 수 있는 시간 (ISO 8601 형식)",
-                example = "2025-07-01T12:00:00"
+                description = "편지를 열 수 있는 시간 (yyyy-MM-dd)",
+                example = "2025-07-01"
         )
         @NotNull(message = "편지를 열 수 있는 시간은 반드시 지정해야 합니다.")
-        private LocalDateTime availableAt;
+        private LocalDate availableAt;
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/easterEggLetter/dto/EasterEggLetterResponseDTO.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEggLetter/dto/EasterEggLetterResponseDTO.java
@@ -3,14 +3,14 @@ package everTale.everTale_be.domain.easterEggLetter.dto;
 import everTale.everTale_be.domain.easterEggLetter.entity.EasterEggLetter;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @Builder
 public class EasterEggLetterResponseDTO {
     private String content;
     private Integer imageNum;
-    private LocalDateTime availableAt;
+    private LocalDate availableAt;
 
     public static EasterEggLetterResponseDTO from(EasterEggLetter letter) {
         return EasterEggLetterResponseDTO.builder()

--- a/src/main/java/everTale/everTale_be/domain/easterEggLetter/entity/EasterEggLetter.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEggLetter/entity/EasterEggLetter.java
@@ -1,12 +1,13 @@
 package everTale.everTale_be.domain.easterEggLetter.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import everTale.everTale_be.domain.story.entity.Story;
 import everTale.everTale_be.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -18,6 +19,7 @@ public class EasterEggLetter extends BaseTimeEntity{
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(length = 300)
     private String content;
 
     private int imageNum;
@@ -27,13 +29,13 @@ public class EasterEggLetter extends BaseTimeEntity{
     @JsonBackReference
     private Story story;
 
-    private LocalDateTime availableAt;
+    private LocalDate availableAt;
 
     public void updateStory(Story story) {
         this.story = story;
     }
 
-    public void updateLetter(String content, int imageUrl, LocalDateTime availableAt) {
+    public void updateLetter(String content, int imageUrl, LocalDate availableAt) {
         this.content = content;
         this.imageNum = imageUrl;
         this.availableAt = availableAt;

--- a/src/main/java/everTale/everTale_be/domain/easterEggLetter/service/EasterEggLetterService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEggLetter/service/EasterEggLetterService.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Service
 @RequiredArgsConstructor
@@ -71,7 +71,7 @@ public class EasterEggLetterService {
         // 자녀의 경우 공개 시간 확인
         if (role == ProfileType.CHILD) {
             if (letter.getAvailableAt() != null &&
-                    LocalDateTime.now().isBefore(letter.getAvailableAt())) {
+                    LocalDate.now().isBefore(letter.getAvailableAt())) {
                 throw new NotFoundHandler(ErrorStatus.EASTER_EGG_LETTER_NOT_YET_AVAILABLE);
             }
         }


### PR DESCRIPTION
## 연관 이슈
close #38 

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
- easterEggLetter 오픈 시간 형식 및 텍스트 제한 리팩토링

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- easterEggLetter 오픈 시간 형식 yyyy-MM-dd
<img width="864" height="619" alt="스크린샷 2025-08-14 오전 12 19 47" src="https://github.com/user-attachments/assets/57eb399c-2bee-46fd-bb99-558106632fbb" />
<img width="864" height="464" alt="스크린샷 2025-08-14 오전 12 19 57" src="https://github.com/user-attachments/assets/25f44eba-d961-4f92-877a-5f4c014dcbeb" />


## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->
---
