### PR TITLE
[feature] easterEgg 책장 조회 API 구현

### DIFF
--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 public class AuthService {
 
     private final JwtUtil jwtUtil;
-    private final JwtProvider jwtProvider;
     private final TokenAuthService tokenAuthService;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/controller/EasterEggLetterController.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/controller/EasterEggLetterController.java
@@ -2,6 +2,7 @@ package everTale.everTale_be.domain.easterEgg.controller;
 
 import everTale.everTale_be.domain.easterEgg.dto.easterEggLetter.EasterEggLetterRequestDTO;
 import everTale.everTale_be.domain.easterEgg.dto.easterEggLetter.EasterEggLetterResponseDTO;
+import everTale.everTale_be.domain.easterEgg.dto.easterEggLetter.EasterEggLetterStoriesResponseDto;
 import everTale.everTale_be.domain.easterEgg.service.EasterEggLetterService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -9,10 +10,12 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/eastereggs/{storyId}/letters")
+@RequestMapping("/eastereggs")
 @Tag(name = "EasterEggLetter", description = "이스터에그 편지 관리 API")
 @RequiredArgsConstructor
 public class EasterEggLetterController {
@@ -20,7 +23,7 @@ public class EasterEggLetterController {
     private final EasterEggLetterService easterEggLetterService;
 
     @Operation(summary = "이스터에그 편지 생성 API", description = "storyId를 받아 해당 스토리의 이스터에그 편지를 저장한다.")
-    @PostMapping
+    @PostMapping("/{storyId}/letters")
     public ApiResponse<String> saveEasterEggLetter(
             @Parameter(description = "스토리 ID") @PathVariable Long storyId,
             @Valid @RequestBody EasterEggLetterRequestDTO.EasterEggLetterCreateRequestDTO request
@@ -31,7 +34,7 @@ public class EasterEggLetterController {
 
 
     @Operation(summary = "이스터에그 편지 조회 API", description = "스토리 ID에 해당하는 이스터에그 편지 내용을 조회한다.")
-    @GetMapping
+    @GetMapping("/{storyId}/letters")
     public ApiResponse<EasterEggLetterResponseDTO> getEasterEggLetter(
             @Parameter(description = "스토리 ID") @PathVariable Long storyId
     ) {
@@ -40,7 +43,7 @@ public class EasterEggLetterController {
     }
 
     @Operation(summary = "이스터에그 편지 수정 API", description = "스토리 ID를 기준으로 이스터에그 편지를 수정한다.")
-    @PutMapping
+    @PutMapping("/{storyId}/letters")
     public ApiResponse<String> updateEasterEggLetter(
             @Parameter(description = "스토리 ID") @PathVariable Long storyId,
             @Valid @RequestBody EasterEggLetterRequestDTO.EasterEggLetterUpdateRequestDTO request
@@ -51,7 +54,7 @@ public class EasterEggLetterController {
 
 
     @Operation(summary = "이스터에그 편지 삭제 API", description = "스토리 ID를 기준으로 해당 스토리의 이스터에그 편지를 삭제한다.")
-    @DeleteMapping
+    @DeleteMapping("/{storyId}/letters")
     public ApiResponse<String> deleteEasterEggLetter(
             @Parameter(description = "스토리 ID") @PathVariable Long storyId
     ) {
@@ -59,4 +62,19 @@ public class EasterEggLetterController {
         return ApiResponse.onSuccess("이스터에그 편지가 성공적으로 삭제되었습니다.");
     }
 
+    @Operation(summary = "이스터에그 편지 책장 조회", description = "선택한 아이 프로필에서 이스터에그를 만들 수 있는 스토리 리스트를 반환합니다.")
+    @GetMapping("/letters/{profileId}/created")
+    public ApiResponse<EasterEggLetterStoriesResponseDto> getStoriesWithEasterEggVoice(@Parameter(description = "자녀 프로필 ID") @PathVariable Long profileId,
+                                                                                       @PageableDefault(size = 4) Pageable pageable){
+        EasterEggLetterStoriesResponseDto responseDto = easterEggLetterService.getStoriesWithEasterEggLetter(profileId, pageable);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    @Operation(summary = "이스터에그 편지 책장 조회", description = "선택한 아이 프로필에서 이스터에그가 이미 만들어진 스토리 리스트를 반환합니다.")
+    @GetMapping("/letters/{profileId}/creatable")
+    public ApiResponse<EasterEggLetterStoriesResponseDto> getStoriesWithoutEasterEggVoice(@Parameter(description = "자녀 프로필 ID") @PathVariable Long profileId,
+                                                                                          @PageableDefault(size = 4) Pageable pageable){
+        EasterEggLetterStoriesResponseDto responseDto = easterEggLetterService.getStoriesWithoutEasterEggLetter(profileId, pageable);
+        return ApiResponse.onSuccess(responseDto);
+    }
 }

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/controller/EasterEggVoiceController.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/controller/EasterEggVoiceController.java
@@ -2,12 +2,15 @@ package everTale.everTale_be.domain.easterEgg.controller;
 
 import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.request.EasterEggVoiceRegisterRequestDto;
 import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.request.EasterEggVoiceRequestDto;
+import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.response.EasterEggVoiceStoriesResponseDto;
 import everTale.everTale_be.domain.easterEgg.service.EasterEggVoiceService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -44,5 +47,21 @@ public class EasterEggVoiceController {
             return ApiResponse.onSuccess("이곳에는 음성이 없네요. 다른 장면을 눌러 숨겨진 목소리를 찾아볼까요?");
         }
         return ApiResponse.onSuccess(voiceUrl);
+    }
+
+    @Operation(summary = "이스터에그 음성 책장 조회", description = "선택한 아이 프로필에서 이스터에그를 만들 수 있는 스토리 리스트를 반환합니다.")
+    @GetMapping("/voices/{profileId}/created")
+    public ApiResponse<EasterEggVoiceStoriesResponseDto> getStoriesWithEasterEggVoice(@Parameter(description = "자녀 프로필 ID") @PathVariable Long profileId,
+                                                                                      @PageableDefault(size = 4) Pageable pageable){
+        EasterEggVoiceStoriesResponseDto responseDto = easterEggVoiceService.getStoriesWithEasterEggVoice(profileId, pageable);
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    @Operation(summary = "이스터에그 음성 책장 조회", description = "선택한 아이 프로필에서 이스터에그가 이미 만들어진 스토리 리스트를 반환합니다.")
+    @GetMapping("/voices/{profileId}/creatable")
+    public ApiResponse<EasterEggVoiceStoriesResponseDto> getStoriesWithoutEasterEggVoice(@Parameter(description = "자녀 프로필 ID") @PathVariable Long profileId,
+                                                                                         @PageableDefault(size = 4) Pageable pageable){
+        EasterEggVoiceStoriesResponseDto responseDto = easterEggVoiceService.getStoriesWithoutEasterEggVoice(profileId, pageable);
+        return ApiResponse.onSuccess(responseDto);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/dto/easterEggLetter/EasterEggLetterStoriesResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/dto/easterEggLetter/EasterEggLetterStoriesResponseDto.java
@@ -1,0 +1,23 @@
+package everTale.everTale_be.domain.easterEgg.dto.easterEggLetter;
+
+import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
+import everTale.everTale_be.domain.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@Schema(description = "이스터에그 편지 책장 응답 DTO")
+public class EasterEggLetterStoriesResponseDto {
+
+    @Schema(description = "이스터에그 편지 책장 스토리 리스트")
+    private StoryCollectionResponseDto easterEggVoiceStories;
+
+    public static EasterEggLetterStoriesResponseDto of(Page<Story> stories) {
+        return EasterEggLetterStoriesResponseDto.builder()
+                .easterEggVoiceStories(StoryCollectionResponseDto.from(stories))
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/dto/easterEggVoice/response/EasterEggVoiceStoriesResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/dto/easterEggVoice/response/EasterEggVoiceStoriesResponseDto.java
@@ -1,0 +1,23 @@
+package everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.response;
+
+import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
+import everTale.everTale_be.domain.story.entity.Story;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+@Getter
+@Builder
+@Schema(description = "이스터에그 음성 책장 응답 DTO")
+public class EasterEggVoiceStoriesResponseDto {
+
+    @Schema(description = "이스터에그 음성 책장 스토리 리스트")
+    private StoryCollectionResponseDto easterEggVoiceStories;
+
+    public static EasterEggVoiceStoriesResponseDto of(Page<Story> stories) {
+        return EasterEggVoiceStoriesResponseDto.builder()
+                .easterEggVoiceStories(StoryCollectionResponseDto.from(stories))
+                .build();
+    }
+}

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/repository/EasterEggLetterRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/repository/EasterEggLetterRepository.java
@@ -1,0 +1,52 @@
+package everTale.everTale_be.domain.easterEgg.repository;
+
+import everTale.everTale_be.domain.easterEgg.entity.EasterEggLetter;
+import everTale.everTale_be.domain.story.entity.Story;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EasterEggLetterRepository extends JpaRepository<EasterEggLetter, Long> {
+
+    @Query(
+            value = """
+        SELECT DISTINCT s
+        FROM Story s
+        JOIN s.easterEggLetter el
+        WHERE s.profile.id = :profileId
+      """,
+            countQuery = """
+        SELECT COUNT(DISTINCT s.id)
+        FROM Story s
+        JOIN s.easterEggLetter el
+        WHERE s.profile.id = :profileId
+      """
+    )
+    Page<Story> findStoriesWithEasterEggLetter(@Param("profileId") Long profileId, Pageable pageable);
+
+    @Query(
+            value = """
+        SELECT s
+        FROM Story s
+        WHERE s.profile.id = :profileId
+          AND NOT EXISTS (
+            SELECT 1
+            FROM EasterEggLetter el
+            WHERE el.story = s
+          )
+      """,
+            countQuery = """
+        SELECT COUNT(s.id)
+        FROM Story s
+        WHERE s.profile.id = :profileId
+          AND NOT EXISTS (
+            SELECT 1
+            FROM EasterEggLetter el
+            WHERE el.story = s
+          )
+      """
+    )
+    Page<Story> findStoriesWithoutEasterEggLetter(@Param("profileId") Long profileId, Pageable pageable);
+}

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/repository/EasterEggVoiceRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/repository/EasterEggVoiceRepository.java
@@ -1,11 +1,60 @@
 package everTale.everTale_be.domain.easterEgg.repository;
 
 import everTale.everTale_be.domain.easterEgg.entity.EasterEggVoice;
+import everTale.everTale_be.domain.story.entity.Story;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface EasterEggVoiceRepository extends JpaRepository<EasterEggVoice, Long> {
 
     Optional<EasterEggVoice> findByScene_Id(Long sceneId);
+
+    @Query(
+            value = """
+            SELECT DISTINCT s
+            FROM Story s
+            JOIN s.storyScenes sc
+            JOIN sc.easterEggVoice ev
+            WHERE s.profile.id = :profileId
+        """,
+            countQuery = """
+            SELECT COUNT(DISTINCT s.id)
+            FROM Story s
+            JOIN s.storyScenes sc
+            JOIN sc.easterEggVoice ev
+            WHERE s.profile.id = :profileId
+        """
+    )
+    Page<Story> findStoriesWithEasterEggVoice(@Param("profileId") Long profileId, Pageable pageable);
+
+    @Query(
+            value = """
+            SELECT s
+            FROM Story s
+            WHERE s.profile.id = :profileId
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM Scene sc
+                  JOIN sc.easterEggVoice ev
+                  WHERE sc.story = s
+              )
+        """,
+            countQuery = """
+            SELECT COUNT(s.id)
+            FROM Story s
+            WHERE s.profile.id = :profileId
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM Scene sc
+                  JOIN sc.easterEggVoice ev
+                  WHERE sc.story = s
+              )
+        """
+    )
+    Page<Story> findStoriesWithoutEasterEggVoice(@Param("profileId") Long profileId, Pageable pageable);
 }

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggLetterService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggLetterService.java
@@ -135,6 +135,7 @@ public class EasterEggLetterService {
 
     public EasterEggLetterStoriesResponseDto getStoriesWithEasterEggLetter(Long profileId, Pageable pageable){
         Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.isParent(profile);
         profileService.validateParentProfileAccess(profile, profileId);
 
         Page<Story> withLetter = easterEggLetterRepository.findStoriesWithEasterEggLetter(profileId, pageable);
@@ -144,6 +145,7 @@ public class EasterEggLetterService {
 
     public EasterEggLetterStoriesResponseDto getStoriesWithoutEasterEggLetter(Long profileId, Pageable pageable){
         Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.isParent(profile);
         profileService.validateParentProfileAccess(profile, profileId);
 
         Page<Story> withoutLetter = easterEggLetterRepository.findStoriesWithoutEasterEggLetter(profileId, pageable);

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggLetterService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggLetterService.java
@@ -2,9 +2,12 @@ package everTale.everTale_be.domain.easterEgg.service;
 
 import everTale.everTale_be.domain.easterEgg.dto.easterEggLetter.EasterEggLetterRequestDTO;
 import everTale.everTale_be.domain.easterEgg.dto.easterEggLetter.EasterEggLetterResponseDTO;
+import everTale.everTale_be.domain.easterEgg.dto.easterEggLetter.EasterEggLetterStoriesResponseDto;
 import everTale.everTale_be.domain.easterEgg.entity.EasterEggLetter;
+import everTale.everTale_be.domain.easterEgg.repository.EasterEggLetterRepository;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
+import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.entity.Story;
 import everTale.everTale_be.domain.story.repository.StoryRepository;
@@ -13,6 +16,8 @@ import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandle
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +30,8 @@ public class EasterEggLetterService {
 
     private final StoryRepository storyRepository;
     private final ProfileHelper profileHelper;
+    private final EasterEggLetterRepository easterEggLetterRepository;
+    private final ProfileService profileService;
 
     // 이스터에그 편지 생성
     @Transactional
@@ -126,6 +133,23 @@ public class EasterEggLetterService {
         return letter;
     }
 
+    public EasterEggLetterStoriesResponseDto getStoriesWithEasterEggLetter(Long profileId, Pageable pageable){
+        Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.validateParentProfileAccess(profile, profileId);
+
+        Page<Story> withLetter = easterEggLetterRepository.findStoriesWithEasterEggLetter(profileId, pageable);
+
+        return EasterEggLetterStoriesResponseDto.of(withLetter);
+    }
+
+    public EasterEggLetterStoriesResponseDto getStoriesWithoutEasterEggLetter(Long profileId, Pageable pageable){
+        Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.validateParentProfileAccess(profile, profileId);
+
+        Page<Story> withoutLetter = easterEggLetterRepository.findStoriesWithoutEasterEggLetter(profileId, pageable);
+
+        return EasterEggLetterStoriesResponseDto.of(withoutLetter);
+    }
 }
 
 

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggVoiceService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggVoiceService.java
@@ -2,12 +2,15 @@ package everTale.everTale_be.domain.easterEgg.service;
 
 import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.request.EasterEggVoiceRegisterRequestDto;
 import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.request.EasterEggVoiceRequestDto;
+import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.response.EasterEggVoiceStoriesResponseDto;
 import everTale.everTale_be.domain.easterEgg.entity.EasterEggVoice;
 import everTale.everTale_be.domain.easterEgg.repository.EasterEggVoiceRepository;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
+import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.entity.Scene;
+import everTale.everTale_be.domain.story.entity.Story;
 import everTale.everTale_be.domain.story.repository.SceneRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
@@ -15,12 +18,15 @@ import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHand
 import everTale.everTale_be.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EasterEggVoiceService {
 
@@ -28,6 +34,7 @@ public class EasterEggVoiceService {
     private final S3Manager s3Manager;
     private final SceneRepository sceneRepository;
     private final EasterEggVoiceRepository easterEggVoiceRepository;
+    private final ProfileService profileService;
 
     @Transactional
     public void createEasterEggVoice(Long sceneId, MultipartFile voiceFile, EasterEggVoiceRegisterRequestDto requestDto){
@@ -57,10 +64,26 @@ public class EasterEggVoiceService {
         scene.setEasterEggVoice(null);
         s3Manager.deleteFile(voice.getVoiceFile());
         easterEggVoiceRepository.delete(voice);
-        log.info("삭제 완료: audioId = {}", voice.getId());
     }
 
-    @Transactional(readOnly = true)
+    public EasterEggVoiceStoriesResponseDto getStoriesWithEasterEggVoice(Long profileId, Pageable pageable){
+        Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.validateParentProfileAccess(profile, profileId);
+
+        Page<Story> withVoice = easterEggVoiceRepository.findStoriesWithEasterEggVoice(profileId, pageable);
+
+        return EasterEggVoiceStoriesResponseDto.of(withVoice);
+    }
+
+    public EasterEggVoiceStoriesResponseDto getStoriesWithoutEasterEggVoice(Long profileId, Pageable pageable){
+        Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.validateParentProfileAccess(profile, profileId);
+
+        Page<Story> withoutVoice = easterEggVoiceRepository.findStoriesWithoutEasterEggVoice(profileId, pageable);
+
+        return EasterEggVoiceStoriesResponseDto.of(withoutVoice);
+    }
+
     public String getVoiceUrl(Long sceneId, EasterEggVoiceRequestDto requestDto) {
         EasterEggVoice voice = easterEggVoiceRepository.findByScene_Id(sceneId)
                 .orElseThrow(()-> new NotFoundHandler(ErrorStatus.EASTER_EGG_VOICE_NOT_FOUND));
@@ -80,13 +103,11 @@ public class EasterEggVoiceService {
         return clickX >= xLeft && clickX <= xRight && clickY <= yTop && clickY >= yBottom;
     }
 
-    @Transactional(readOnly = true)
     private Scene findScene(Long sceneId){
         return sceneRepository.findById(sceneId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.SCENE_NOT_FOUND));
     }
 
-    @Transactional(readOnly = true)
     private void validateParent() {
         Profile profile = profileHelper.getAuthenticatedProfile();
         if (profile.getProfileType() != ProfileType.PARENT) {

--- a/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggVoiceService.java
+++ b/src/main/java/everTale/everTale_be/domain/easterEgg/service/EasterEggVoiceService.java
@@ -5,6 +5,7 @@ import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.request.EasterEg
 import everTale.everTale_be.domain.easterEgg.dto.easterEggVoice.response.EasterEggVoiceStoriesResponseDto;
 import everTale.everTale_be.domain.easterEgg.entity.EasterEggVoice;
 import everTale.everTale_be.domain.easterEgg.repository.EasterEggVoiceRepository;
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileStatus;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import everTale.everTale_be.domain.profile.service.ProfileService;
@@ -14,7 +15,6 @@ import everTale.everTale_be.domain.story.entity.Story;
 import everTale.everTale_be.domain.story.repository.SceneRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
-import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import everTale.everTale_be.global.s3.S3Manager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,7 +38,8 @@ public class EasterEggVoiceService {
 
     @Transactional
     public void createEasterEggVoice(Long sceneId, MultipartFile voiceFile, EasterEggVoiceRegisterRequestDto requestDto){
-        validateParent();
+        Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.isParent(profile);
         Scene scene = findScene(sceneId);
 
         String voiceUrl = s3Manager.uploadFile(voiceFile, "eastereggs/audios");
@@ -56,7 +57,8 @@ public class EasterEggVoiceService {
 
     @Transactional
     public void deleteEasterEggVoice(Long sceneId){
-        validateParent();
+        Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.isParent(profile);
 
         EasterEggVoice voice = easterEggVoiceRepository.findByScene_Id(sceneId)
                 .orElseThrow(()-> new NotFoundHandler(ErrorStatus.EASTER_EGG_VOICE_NOT_FOUND));
@@ -68,6 +70,7 @@ public class EasterEggVoiceService {
 
     public EasterEggVoiceStoriesResponseDto getStoriesWithEasterEggVoice(Long profileId, Pageable pageable){
         Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.isParent(profile);
         profileService.validateParentProfileAccess(profile, profileId);
 
         Page<Story> withVoice = easterEggVoiceRepository.findStoriesWithEasterEggVoice(profileId, pageable);
@@ -77,6 +80,7 @@ public class EasterEggVoiceService {
 
     public EasterEggVoiceStoriesResponseDto getStoriesWithoutEasterEggVoice(Long profileId, Pageable pageable){
         Profile profile = profileHelper.getAuthenticatedProfile();
+        profileService.isParent(profile);
         profileService.validateParentProfileAccess(profile, profileId);
 
         Page<Story> withoutVoice = easterEggVoiceRepository.findStoriesWithoutEasterEggVoice(profileId, pageable);
@@ -106,12 +110,5 @@ public class EasterEggVoiceService {
     private Scene findScene(Long sceneId){
         return sceneRepository.findById(sceneId)
                 .orElseThrow(() -> new NotFoundHandler(ErrorStatus.SCENE_NOT_FOUND));
-    }
-
-    private void validateParent() {
-        Profile profile = profileHelper.getAuthenticatedProfile();
-        if (profile.getProfileType() != ProfileType.PARENT) {
-            throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
-        }
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -19,7 +19,6 @@ import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.BadRequestHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
-import org.springframework.core.io.support.SpringFactoriesLoader;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -151,5 +150,18 @@ public class ProfileService {
 
         tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
         profileRepository.anonymizeProfile(profileId);
+    }
+
+    public void validateChildProfileAccess(Profile profile, Long profileId) {
+        if (!profile.getId().equals(profileId)) {
+            throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+        }
+    }
+
+    public void validateParentProfileAccess(Profile parent, Long profileId) {
+        boolean isMyChild = profileRepository.existsByUserIdAndId(parent.getUser().getId(), profileId);
+        if (!isMyChild) {
+            throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+        }
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -152,6 +152,12 @@ public class ProfileService {
         profileRepository.anonymizeProfile(profileId);
     }
 
+    public void isParent(Profile profile) {
+        if (profile.getProfileType() != ProfileType.PARENT) {
+            throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
+        }
+    }
+
     public void validateChildProfileAccess(Profile profile, Long profileId) {
         if (!profile.getId().equals(profileId)) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -8,7 +8,7 @@ import everTale.everTale_be.domain.character.repository.StoryCharacterRepository
 import everTale.everTale_be.domain.easterEgg.entity.EasterEggVoice;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
-import everTale.everTale_be.domain.profile.repository.ProfileRepository;
+import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.dto.SceneResponseDTO;
 import everTale.everTale_be.domain.story.dto.StoryCollectionResponseDto;
@@ -21,7 +21,6 @@ import everTale.everTale_be.domain.story.repository.StoryRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
 import everTale.everTale_be.domain.story.external.StoryApiClient;
-import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import everTale.everTale_be.global.s3.S3Manager;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,7 +43,7 @@ public class StoryService {
     private final StoryRepository storyRepository;
     private final StoryCharacterRepository storyCharacterRepository;
     private final PersonalityRepository personalityRepository;
-    private final ProfileRepository profileRepository;
+    private final ProfileService profileService;
     private final StoryApiClient storyApiClient;
     private final ProfileHelper profileHelper;
     private final S3Manager s3Manager;
@@ -342,14 +341,9 @@ public class StoryService {
         Profile profile = profileHelper.getAuthenticatedProfile();
 
         if (profile.getProfileType()== ProfileType.CHILD) {
-            if (!profile.getId().equals(profileId)) {
-                throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
-            }
+            profileService.validateChildProfileAccess(profile, profileId);
         } else {
-            boolean isMyChild = profileRepository.existsByUserIdAndId(profile.getId(), profileId);
-            if (!isMyChild) {
-                throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
-            }
+            profileService.validateParentProfileAccess(profile, profileId);
         }
 
         Page<Story> stories = storyRepository.findByProfileId(profileId, pageable);


### PR DESCRIPTION
## 연관 이슈
close #48 

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
이스터에그 음성/편지 API를 "생성된 스토리"와 "생성 가능한 스토리"로 분리하여 조회하는 api를 개발하였습니당.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- easterEggLetter `CREATED`
<img width="924" height="728" alt="스크린샷 2025-08-17 오후 4 20 29" src="https://github.com/user-attachments/assets/0e7d2e6c-10fd-4c7d-9a02-ae3e847f177b" />

- easterEggLetter `CREATABLE`
<img width="926" height="804" alt="스크린샷 2025-08-17 오후 4 20 38" src="https://github.com/user-attachments/assets/72d812a3-5e1e-4d78-8416-2653aa28fa9e" />

- easterEggVoice `CREATED`
<img width="918" height="645" alt="스크린샷 2025-08-17 오후 4 25 56" src="https://github.com/user-attachments/assets/0072c14e-6977-4d6c-abb7-22c2a47f53e8" />

- easterEggVoice `CREATABLE`
<img width="916" height="747" alt="스크린샷 2025-08-17 오후 4 26 05" src="https://github.com/user-attachments/assets/3400a5f1-4047-442a-835d-b736bfb4b373" />

## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->

---
