### PR TITLE
[refactor] 프로필 기반 로그아웃/탈퇴(삭제)/reissue 코드 구조 수정

### DIFF
--- a/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
+++ b/src/main/java/everTale/everTale_be/auth/controller/AuthController.java
@@ -49,13 +49,6 @@ public class AuthController {
         return ApiResponse.onSuccess(responseDto);
     }
 
-    @PostMapping("/profile/reissue")
-    @Operation(summary = "프로필 기반 AccessToken 재발급", description = "만료된 access token을 refresh token으로 재발급합니다.")
-    public ApiResponse<ProfileEnterResponseDto> reissueProfileAccessToken(@Valid @RequestBody ProfileReissueRequestDto requestDto) {
-        ProfileEnterResponseDto responseDto = profileService.reissueWithProfile(requestDto.getRefreshToken(), requestDto.getProfileId());
-        return ApiResponse.onSuccess(responseDto);
-    }
-
     // 로그아웃
     @Operation(summary = "로그아웃", description = "현재 로그인한 사용자의 토큰을 만료 처리합니다.")
     @PostMapping("/logout")
@@ -74,5 +67,32 @@ public class AuthController {
 
         authService.withdraw(accessToken);
         return ApiResponse.onSuccess("회원 탈퇴가 성공적으로 완료되었습니다.");
+    }
+
+    @PostMapping("/profile/reissue")
+    @Operation(summary = "프로필 기반 AccessToken 재발급", description = "만료된 access token을 refresh token으로 재발급합니다.")
+    public ApiResponse<ProfileEnterResponseDto> reissueProfileAccessToken(@Valid @RequestBody ProfileReissueRequestDto requestDto) {
+        ProfileEnterResponseDto responseDto = authService.reissueWithProfile(requestDto.getRefreshToken());
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    // 프로필 로그아웃
+    @Operation(summary = "프로필 로그아웃", description = "선택한 프로필에서 로그아웃합니다.")
+    @DeleteMapping("/profile/logout")
+    public ApiResponse<String> logoutProfile(HttpServletRequest request){
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        authService.logoutProfile(accessToken);
+        return ApiResponse.onSuccess("로그아웃이 성공적으로 완료되었습니다.");
+    }
+
+    // 프로필 삭제
+    @Operation(summary = "프로필 삭제", description = "선택한 프로필을 삭제합니다.")
+    @DeleteMapping("/profile")
+    public ApiResponse<String> deleteProfile(HttpServletRequest request){
+        String accessToken = jwtUtil.extractAccessToken(request);
+
+        authService.deleteProfile(accessToken);
+        return ApiResponse.onSuccess("프로필이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/everTale/everTale_be/auth/dto/request/ProfileReissueRequestDto.java
+++ b/src/main/java/everTale/everTale_be/auth/dto/request/ProfileReissueRequestDto.java
@@ -12,7 +12,4 @@ public class ProfileReissueRequestDto {
 
     @Schema(description = "Refresh Token", example = "eyJhbGciOiJIUzI1NiIsInR5cCI...")
     private String refreshToken;
-
-    @Schema(description = "프로필 ID", example = "42")
-    private Long profileId;
 }

--- a/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
+++ b/src/main/java/everTale/everTale_be/auth/jwt/JwtProvider.java
@@ -65,6 +65,11 @@ public class JwtProvider {
         return claims.get("userId", Long.class);
     }
 
+    public Long getProfileIdFromToken(String token) {
+        Claims claims = jwtUtil.extractClaims(token);
+        return claims.get("profileId", Long.class);
+    }
+
     public boolean isTokenContainsProfileId(String token) {
         Claims claims = jwtUtil.extractClaims(token);
         return claims.containsKey("profileId");

--- a/src/main/java/everTale/everTale_be/auth/service/AuthService.java
+++ b/src/main/java/everTale/everTale_be/auth/service/AuthService.java
@@ -7,6 +7,10 @@ import everTale.everTale_be.auth.dto.response.UserInfoResponseDto;
 import everTale.everTale_be.auth.jwt.JwtProvider;
 import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.auth.util.UserHelper;
+import everTale.everTale_be.domain.profile.dto.response.ProfileEnterResponseDto;
+import everTale.everTale_be.domain.profile.entity.Profile;
+import everTale.everTale_be.domain.profile.repository.ProfileRepository;
+import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.user.entity.Enum.LoginProvider;
 import everTale.everTale_be.domain.user.entity.User;
 import everTale.everTale_be.domain.user.repository.UserRepository;
@@ -25,11 +29,14 @@ import java.util.Optional;
 public class AuthService {
 
     private final JwtUtil jwtUtil;
+    private final JwtProvider jwtProvider;
     private final TokenAuthService tokenAuthService;
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
     private final NaverService naverService;
     private final UserHelper userHelper;
+    private final ProfileHelper profileHelper;
+    private final ProfileRepository profileRepository;
 
     // 일반 회원가입
     public void signup(SignUpRequestDto requestDto) {
@@ -97,20 +104,54 @@ public class AuthService {
 
     // 로그아웃
     public void logout(String accessToken) {
-        Long userId = userHelper.getRootUserId();
         tokenAuthService.validateNotBlackListed(accessToken);
-
         tokenAuthService.addToBlackListForAccessToken(accessToken, "LOGOUT");
-        tokenAuthService.deleteRefreshToken(userId);
     }
 
     // 회원 탈퇴
     public void withdraw(String accessToken) {
         Long userId = userHelper.getRootUserId();
         tokenAuthService.validateNotBlackListed(accessToken);
+        tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
+        userRepository.anonymizeUser(userId);
+    }
+
+    public ProfileEnterResponseDto reissueWithProfile(String refreshToken) {
+        Long userId = jwtProvider.getUserIdFromToken(refreshToken);
+        Long profileId = jwtProvider.getProfileIdFromToken(refreshToken);
+
+        String storedRefreshToken = tokenAuthService.getRefreshToken(profileId);
+        if (!storedRefreshToken.equals(refreshToken)) {
+            throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
+        }
+
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(userId, profile.getId());
+        String newRefreshToken = jwtUtil.generateRefreshTokenWithProfile(userId, profile.getId());
+        tokenAuthService.saveRefreshToken(profileId, newRefreshToken);
+
+        return ProfileEnterResponseDto.from(profile, newAccessToken, newRefreshToken, jwtUtil);
+    }
+
+    // 프로필 나가기 (프로필 로그아웃)
+    public void logoutProfile(String accessToken){
+        Long profileId = profileHelper.getAuthenticatedProfileId();
+        tokenAuthService.validateNotBlackListed(accessToken);
+
+        tokenAuthService.addToBlackListForAccessToken(accessToken, "LOGOUT");
+        tokenAuthService.deleteRefreshToken(profileId);
+    }
+
+    // 프로필 삭제 (회원 탈퇴 X)
+    public void deleteProfile(String accessToken){
+        Long profileId = profileHelper.getAuthenticatedProfileId();
+        Profile profile = profileRepository.findById(profileId)
+                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
+        profile.deleteProfile();
 
         tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
-        tokenAuthService.deleteRefreshToken(userId);
-        userRepository.anonymizeUser(userId);
+        tokenAuthService.deleteRefreshToken(profileId);
+        profileRepository.anonymizeProfile(profileId);
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
@@ -11,7 +11,6 @@ import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -85,15 +84,5 @@ public class ProfileController {
     public ApiResponse<String> updatePassword(@Valid @RequestBody PasswordUpdateRequestDto requestDto) {
         profileService.updatePassword(requestDto);
         return ApiResponse.onSuccess("비밀번호가 성공적으로 수정되었습니다.");
-    }
-
-    // 프로필 삭제
-    @Operation(summary = "프로필 삭제", description = "선택한 프로필을 삭제합니다.")
-    @DeleteMapping
-    public ApiResponse<String> deleteProfile(HttpServletRequest request){
-        String accessToken = jwtUtil.extractAccessToken(request);
-
-        profileService.deleteProfile(accessToken);
-        return ApiResponse.onSuccess("프로필이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/dto/request/ChildProfileRequestDto.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/dto/request/ChildProfileRequestDto.java
@@ -1,6 +1,7 @@
 package everTale.everTale_be.domain.profile.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileStatus;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import everTale.everTale_be.domain.user.entity.User;
@@ -29,12 +30,13 @@ public class ChildProfileRequestDto {
     @Schema(description = "자녀 기관명", example = "새싹 유치원")
     private String institution;
 
-    public Profile toEntity(User user, ProfileType profileType){
+    public Profile toEntity(User user, ProfileType profileType, ProfileStatus profileStatus){
         return Profile.builder()
                 .name(name)
                 .birthDate(birthDate)
                 .institution(institution)
                 .profileType(profileType)
+                .profileStatus(profileStatus)
                 .user(user)
                 .build();
     }

--- a/src/main/java/everTale/everTale_be/domain/profile/entity/Enum/ProfileStatus.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/entity/Enum/ProfileStatus.java
@@ -1,0 +1,7 @@
+package everTale.everTale_be.domain.profile.entity.Enum;
+
+public enum ProfileStatus {
+    ACTIVE,
+    DEACTIVATED,
+    DELETED
+}

--- a/src/main/java/everTale/everTale_be/domain/profile/entity/Profile.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/entity/Profile.java
@@ -1,5 +1,6 @@
 package everTale.everTale_be.domain.profile.entity;
 
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileStatus;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.dto.request.ChildProfileUpdateRequestDto;
 import everTale.everTale_be.domain.profile.dto.request.ParentProfileUpdateRequestDto;
@@ -49,6 +50,10 @@ public class Profile extends BaseTimeEntity {
     @Column(name = "profile_type", nullable = false)
     private ProfileType profileType;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProfileStatus profileStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", updatable = false, nullable = false)
     private User user;
@@ -66,6 +71,7 @@ public class Profile extends BaseTimeEntity {
                    String phone,
                    String email,
                    ProfileType profileType,
+                   ProfileStatus profileStatus,
                    Badge badge,
                    User user) {
         this.name = name;
@@ -74,6 +80,7 @@ public class Profile extends BaseTimeEntity {
         this.phone = phone;
         this.email = email;
         this.profileType = profileType;
+        this.profileStatus = profileStatus;
         this.user = user;
         this.badge = (badge != null) ? badge : Badge.fromSolvedCount(this.quizSolvedCount);
 
@@ -97,5 +104,9 @@ public class Profile extends BaseTimeEntity {
 
     public void refreshBadge() {
         this.badge = Badge.fromSolvedCount(this.quizSolvedCount);
+    }
+
+    public void deleteProfile(){
+        this.profileStatus = ProfileStatus.DELETED;
     }
 }

--- a/src/main/java/everTale/everTale_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/repository/ProfileRepository.java
@@ -1,5 +1,6 @@
 package everTale.everTale_be.domain.profile.repository;
 
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileStatus;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,7 +19,7 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
     boolean existsByUserIdAndId(Long userId, Long id);
 
     // 현재 로그인한 회원의 프로필들 가져오기
-    List<Profile> findAllByUserId(Long userId);
+    List<Profile> findAllByUserIdAndProfileStatusNot(Long userId, ProfileStatus status);
 
     @Modifying
     @Transactional

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -4,6 +4,7 @@ import everTale.everTale_be.auth.jwt.JwtProvider;
 import everTale.everTale_be.auth.jwt.JwtUtil;
 import everTale.everTale_be.auth.service.TokenAuthService;
 import everTale.everTale_be.auth.util.UserHelper;
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileStatus;
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import everTale.everTale_be.domain.profile.dto.request.ChildProfileRequestDto;
@@ -46,7 +47,7 @@ public class ProfileService {
         if (exists){
             throw new BadRequestHandler(ErrorStatus.ALREADY_EXISTS_PROFILE);
         }
-        profileRepository.save(requestDto.toEntity(rootUser, ProfileType.CHILD));
+        profileRepository.save(requestDto.toEntity(rootUser, ProfileType.CHILD, ProfileStatus.ACTIVE));
     }
 
     public void createParentProfile() {
@@ -62,6 +63,7 @@ public class ProfileService {
                 .phone(rootUser.getPhone())
                 .user(rootUser)
                 .profileType(ProfileType.PARENT)
+                .profileStatus(ProfileStatus.ACTIVE)
                 .build();
 
         profileRepository.save(parentProfile);
@@ -70,7 +72,7 @@ public class ProfileService {
     @Transactional(readOnly = true)
     public ProfileListResponseDto getProfiles(){
         Long userId = userHelper.getRootUserId();
-        List<Profile> profiles = profileRepository.findAllByUserId(userId);
+        List<Profile> profiles = profileRepository.findAllByUserIdAndProfileStatusNot(userId, ProfileStatus.DELETED);
 
         return ProfileListResponseDto.from(profiles);
     }
@@ -127,43 +129,21 @@ public class ProfileService {
         rootUser.changePassword(passwordEncoder.encode(requestDto.getNewPassword()));
     }
 
-    public ProfileEnterResponseDto reissueWithProfile(String refreshToken, Long profileId) {
-        Long userId = jwtProvider.getUserIdFromToken(refreshToken);
-
-        String storedRefreshToken = tokenAuthService.getRefreshToken(userId);
-        if (!storedRefreshToken.equals(refreshToken)) {
-            throw new UnAuthorizedHandler(ErrorStatus.INVALID_REFRESH_TOKEN);
-        }
-
-        Profile profile = profileRepository.findById(profileId)
-                .orElseThrow(()-> new NotFoundHandler(ErrorStatus.NOT_FOUND_PROFILE));
-        String newAccessToken = jwtUtil.generateAccessTokenWithProfile(userId, profile.getId());
-        String newRefreshToken = jwtUtil.generateRefreshTokenWithProfile(userId, profile.getId());
-        tokenAuthService.saveRefreshToken(profileId, newRefreshToken);
-
-        return ProfileEnterResponseDto.from(profile, newAccessToken, newRefreshToken, jwtUtil);
-    }
-
-    // 프로필 삭제 (회원 탈퇴 X)
-    public void deleteProfile(String accessToken){
-        Long profileId = profileHelper.getAuthenticatedProfileId();
-
-        tokenAuthService.addToBlackListForAccessToken(accessToken, "WITHDRAW");
-        profileRepository.anonymizeProfile(profileId);
-    }
-
+    @Transactional(readOnly = true)
     public void isParent(Profile profile) {
         if (profile.getProfileType() != ProfileType.PARENT) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
     }
 
+    @Transactional(readOnly = true)
     public void validateChildProfileAccess(Profile profile, Long profileId) {
         if (!profile.getId().equals(profileId)) {
             throw new UnAuthorizedHandler(ErrorStatus.UNAUTHORIZED_PROFILE_ACCESS);
         }
     }
 
+    @Transactional(readOnly = true)
     public void validateParentProfileAccess(Profile parent, Long profileId) {
         boolean isMyChild = profileRepository.existsByUserIdAndId(parent.getUser().getId(), profileId);
         if (!isMyChild) {


### PR DESCRIPTION
## 연관 이슈
close #50 

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
프로필 기반으로 로그아웃, 토큰 재발급(reissue), 탈퇴(프로필 삭제)가 되도록 리팩토링 하였습니당.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
기존 동작 방식과 똑같지만, 이제는 프로필 단위로 accessToken 과 refreshToken을 발급받기 때문에 토큰 reissue시에 profileId를 따로 보내야하지않아도 됩니당.
이 외에는 리프레쉬 토큰 삭제와 엑세스 토큰 블랙리스트 추가는 기존과 같게 작동합니다.
<img width="721" height="187" alt="스크린샷 2025-08-17 오후 6 23 51" src="https://github.com/user-attachments/assets/66cc41a2-19d1-4de4-93ad-b7d8274998a8" />


## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->

---
