### PR TITLE
[refactor] 이미지 생성을 위한 프롬프트를 scene내용 -> 프롬프트 직접 입력으로 변경

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
+++ b/src/main/java/everTale/everTale_be/domain/story/controller/StoryController.java
@@ -8,12 +8,12 @@ import everTale.everTale_be.domain.story.service.StoryService;
 import everTale.everTale_be.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.MediaType;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -128,7 +128,7 @@ public class StoryController {
         String nextStory = storyService.generateNextSceneWithAnswer(storyId, pageNum, request.getAnswer());
         return ApiResponse.onSuccess(nextStory);
     }
-    @Operation(summary = "스케치 기반 이미지 생성 API", description = "아이의 스케치 이미지와 줄거리를 기반으로 이미지를 생성합니다.")
+    @Operation(summary = "스케치 기반 이미지 생성 API", description = "아이의 스케치 이미지와 장면 프롬프트를 기반으로 이미지를 생성합니다.")
     @PostMapping(
             value = "/{storyId}/scenes/{pageNum}/controlnet",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
@@ -136,10 +136,9 @@ public class StoryController {
     public ApiResponse<String> createImageFromSketch(
             @Parameter(description = "스토리 ID") @PathVariable Long storyId,
             @Parameter(description = "페이지 번호(1~8)") @PathVariable int pageNum,
-            @Parameter(description = "스케치 이미지 파일", content = @Content(mediaType = MediaType.APPLICATION_OCTET_STREAM_VALUE))
-            @RequestPart("sketch") MultipartFile sketch
-    ) {
-        String image = storyService.generateImageFromSketch(storyId, pageNum, sketch);
+            @Validated @ModelAttribute StoryRequestDTO.SketchImageRequestDTO request
+            ) {
+        String image = storyService.generateImageFromSketch(storyId, pageNum, request);
         return ApiResponse.onSuccess(image);
     }
 

--- a/src/main/java/everTale/everTale_be/domain/story/dto/StoryRequestDTO.java
+++ b/src/main/java/everTale/everTale_be/domain/story/dto/StoryRequestDTO.java
@@ -3,6 +3,7 @@ package everTale.everTale_be.domain.story.dto;
 import everTale.everTale_be.domain.story.entity.enums.Genre;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -82,6 +83,16 @@ public class StoryRequestDTO {
     public static class StoryUpdateRequestDTO {
         @Schema(description = "수정된 줄거리 내용", example = "주인공은 용기를 내어 드래곤에게 다가갔다.")
         private String updatedContent;
+    }
+    @Data
+    @AllArgsConstructor
+    public static class SketchImageRequestDTO {
+
+        @Schema(description = "장면 프롬프트", example = "A little girl holding a balloon")
+        private String prompt;
+
+        @Schema(type = "string", format = "binary", description = "스케치 이미지 파일")
+        private MultipartFile sketch;
     }
 
     @Getter

--- a/src/main/java/everTale/everTale_be/domain/story/entity/Scene.java
+++ b/src/main/java/everTale/everTale_be/domain/story/entity/Scene.java
@@ -16,6 +16,7 @@ public class Scene {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     private int page;

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -295,14 +295,11 @@ public class StoryService {
         story.addScene(newScene);
         return nextContent;
     }
-    // 줄거리 및 아이그림 기반 그림 생성
+    // 장면 프롬프트 및 아이그림 기반 그림 생성
     @Transactional
-    public String generateImageFromSketch(Long storyId, int pageNum, MultipartFile sketch) {
+    public String generateImageFromSketch(Long storyId, int pageNum, StoryRequestDTO.SketchImageRequestDTO request) {
         Scene scene = findMyScene(storyId, pageNum);
-
-        String prompt = scene.getContent();
-        String imageUrl = storyApiClient.callFastApiForImageFromSketch(sketch, prompt, scene.getStory().getGenre().name());
-
+        String imageUrl = storyApiClient.callFastApiForImageFromSketch(request.getSketch(), request.getPrompt(), scene.getStory().getGenre().name());
         scene.updateImageUrl(imageUrl);
         return imageUrl;
     }


### PR DESCRIPTION
## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 피그마 구성에 맞추어 이미지 생성을 위한 프롬프트를 scene내용 -> 프롬프트 직접 입력으로 변경

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- 피그마 화면 구성에 맞추어 이미지에 대한 설명 프롬프트를 직접 입력하는 방식으로 변경하였습니다.
<img width="988" height="701" alt="스크린샷 2025-08-20 오전 3 06 47" src="https://github.com/user-attachments/assets/8d366140-1f41-4ab4-9046-9a4c4dfe6937" />

  - 기존에 줄거리내용을 받아와 요약해서 프롬프트에 삽입하는 방식이나
  - 줄거리 + 프롬프트 직접 입력 방식은 이미지에 대한 정확한 설명이 아니라 오히려 scribble 정확도가 떨어져서
  - 프롬프트만 입력하는 방식으로 변경하였습니다.
  ---
<img width="862" height="865" alt="스크린샷 2025-08-20 오전 3 20 41" src="https://github.com/user-attachments/assets/ece5b58b-482d-414c-b639-64d70be42a0f" />

---
- (cf)로컬 mps로 돌려서 cuda로 돌리는 것 보다 이미지 퀄리티가 떨어진 상태입니다
<img width="300" height="300" alt="숲길" src="https://github.com/user-attachments/assets/e7767dbc-f237-45cf-8346-5aa16827357c" />
<img width="300" height="300" alt="숲길" src="https://github.com/user-attachments/assets/1f227b3d-2a27-4e08-955f-95a3a9afce0f" />


