### PR TITLE
[refactor] 알림 조회 응답 데이터 포맷 수정

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/alarm/dto/AlarmSummary.java
+++ b/src/main/java/everTale/everTale_be/domain/alarm/dto/AlarmSummary.java
@@ -20,14 +20,27 @@ public class AlarmSummary {
     @Schema(description = "스토리 ID", example = "12")
     private Long storyId;
 
+    @Schema(description = "알림 메시지", example = "「용과 마음의 열쇠」 ― 숨은 메세지가 도착했어요. 지금 확인해보세요!")
+    private String message;
+
     @Schema(description = "읽음 여부", example = "0")
     private boolean isRead;
 
     public static AlarmSummary from(Alarm alarm){
+        String message;
+        String storyTitle = alarm.getStory().getTitle();
+
+        if (alarm.getAlarmType() == AlarmType.EASTEREGG_VOICE) {
+            message = String.format("「%s」 ― 숨은 메세지가 도착했어요. 지금 확인해보세요!", storyTitle);
+        } else {
+            message = String.format("「%s」 ― 사랑의 편지가 도착했어요. 지금 확인해보세요!", storyTitle);
+        }
+
         return AlarmSummary.builder()
                 .alarmId(alarm.getId())
                 .alarmType(alarm.getAlarmType())
                 .storyId(alarm.getStory().getId())
+                .message(message)
                 .isRead(alarm.isRead())
                 .build();
     }

--- a/src/main/java/everTale/everTale_be/domain/alarm/dto/response/AlarmListResponseDto.java
+++ b/src/main/java/everTale/everTale_be/domain/alarm/dto/response/AlarmListResponseDto.java
@@ -17,6 +17,9 @@ public class AlarmListResponseDto {
     @Schema(description = "알림 요약 리스트")
     private List<AlarmSummary> alarmSummaries;
 
+    @Schema(description = "읽지 않은 알림 개수", example = "3")
+    private long unreadCount;
+
     @Schema(description = "현재 페이지 번호 (0부터 시작)", example = "0")
     private int currentPage;
 
@@ -27,8 +30,13 @@ public class AlarmListResponseDto {
     private long totalCount;
 
     public static AlarmListResponseDto from(Page<Alarm> alarms){
+        long unreadCount = alarms.stream()
+                .filter(alarm -> !alarm.isRead())
+                .count();
+
         return AlarmListResponseDto.builder()
                 .alarmSummaries(alarms.stream().map(AlarmSummary::from).toList())
+                .unreadCount(unreadCount)
                 .currentPage(alarms.getNumber())
                 .totalPage(alarms.getTotalPages())
                 .totalCount(alarms.getTotalElements())

--- a/src/main/java/everTale/everTale_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/everTale/everTale_be/domain/alarm/service/AlarmService.java
@@ -7,6 +7,7 @@ import everTale.everTale_be.domain.alarm.repository.AlarmRepository;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.domain.story.entity.Story;
+import everTale.everTale_be.domain.story.repository.StoryRepository;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.UnAuthorizedHandler;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AlarmService {
 
     private final AlarmRepository alarmRepository;
+    private final StoryRepository storyRepository;
     private final ProfileHelper profileHelper;
 
     @Transactional


### PR DESCRIPTION
## 연관 이슈
close #58  

## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
알림 조회 시, 응답 데이터 필드에 message 내용을 추가하였습니다.
해당 알림과 연관되어있는 `Story`에 따라 제목이 동적으로 바뀌고, `alarmType`에 따라 뒤에 메세지도 동적으로 바뀝니다.
++) 아직 안 읽은 메세지들의 개수를 반환하는 `unreadCount` 필드도 추가했습니다.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- 알림 조회
<img width="911" height="758" alt="스크린샷 2025-09-13 오후 10 07 17" src="https://github.com/user-attachments/assets/026daa7e-d0e5-4678-bfd6-481e181a84f6" />


## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->

---
