### PR TITLE
[feature] 자녀 프로필 조회 API

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/controller/ProfileController.java
@@ -42,9 +42,17 @@ public class ProfileController {
 
     // 프로필 리스트
     @Operation(summary = "프로필 리스트 조회", description = "사용자의 프로필 목록을 조회합니다.")
-    @GetMapping
+    @GetMapping("/all")
     public ApiResponse<ProfileListResponseDto> getProfiles(){
         ProfileListResponseDto responseDto = profileService.getProfiles();
+        return ApiResponse.onSuccess(responseDto);
+    }
+
+    // 자녀 프로필 리스트
+    @Operation(summary = "자녀 프로필 리스트 조회", description = "사용자의 자녀 프로필 목록을 조회합니다.")
+    @GetMapping("/child")
+    public ApiResponse<ProfileListResponseDto> getChildProfiles(){
+        ProfileListResponseDto responseDto = profileService.getChildProfiles();
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/everTale/everTale_be/domain/profile/repository/ProfileRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/repository/ProfileRepository.java
@@ -1,6 +1,7 @@
 package everTale.everTale_be.domain.profile.repository;
 
 import everTale.everTale_be.domain.profile.entity.Enum.ProfileStatus;
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
 import everTale.everTale_be.domain.profile.entity.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -20,6 +21,13 @@ public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     // 현재 로그인한 회원의 프로필들 가져오기
     List<Profile> findAllByUserIdAndProfileStatusNot(Long userId, ProfileStatus status);
+
+    // 현재 로그인한 회원의 CHILD 프로필 조회
+    List<Profile> findAllByUserIdAndProfileStatusNotAndProfileType(
+            Long userId,
+            ProfileStatus status,
+            ProfileType profileType
+    );
 
     @Modifying
     @Transactional

--- a/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
+++ b/src/main/java/everTale/everTale_be/domain/profile/service/ProfileService.java
@@ -77,7 +77,15 @@ public class ProfileService {
         return ProfileListResponseDto.from(profiles);
     }
 
-    // 프로필 상세정보 조회
+
+    @Transactional(readOnly = true)
+    public ProfileListResponseDto getChildProfiles(){
+        Long userId = userHelper.getRootUserId();
+        List<Profile> profiles = profileRepository.findAllByUserIdAndProfileStatusNotAndProfileType(userId, ProfileStatus.DELETED, ProfileType.CHILD);
+
+        return ProfileListResponseDto.from(profiles);
+    }
+
     @Transactional(readOnly = true)
     public ProfileInfoResponseDto getProfileInfo(){
         Profile profile = profileHelper.getAuthenticatedProfile();


### PR DESCRIPTION
## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
로그인한 계정에서 부모 프로필 접속 시, 자녀 프로필 리스트를 조회할 수 있는 API를 구현했습니다.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- 자녀 프로필 조회
<img width="914" height="652" alt="스크린샷 2025-10-03 오후 9 10 36" src="https://github.com/user-attachments/assets/6686286b-d2e9-4b5b-86d1-64ad330030bc" />


## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->
기존의 프로필 조회 api path가` /profiles` 였는데, 전체 프로필 조회랑 자녀 프로필 조회를 분리해야할 것 같아서
전체 프로필 조회: `/profiles/all`
자녀 프로필 조회: `/profiles/child`로 api path를 구분해주었습니다.

---
