### PR TITLE
[refactor] Character 조회 시, profileId로 캐릭터 조회

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
+++ b/src/main/java/everTale/everTale_be/domain/character/controller/CharacterController.java
@@ -23,10 +23,11 @@ public class CharacterController {
 
     private final CharacterService characterService;
 
-    @Operation(summary = "내가 만든 스토리의 캐릭터 목록 조회", description = "내가 작성한 스토리에 등장하는 모든 캐릭터를 페이지네이션 형태로 조회합니다.")
-    @GetMapping
-    public ApiResponse<CharacterCollectionResponseDto> getMyCharacters(@PageableDefault(size = 8) Pageable pageable){
-        CharacterCollectionResponseDto responseDto = characterService.getMyCharacters(pageable);
+    @Operation(summary = "특정 프로필 유저의 스토리 캐릭터 목록 조회", description = "내가 작성한 스토리에 등장하는 모든 캐릭터를 페이지네이션 형태로 조회합니다.")
+    @GetMapping("/list/{profileId}")
+    public ApiResponse<CharacterCollectionResponseDto> getCharacters(@Parameter(description = "프로필 ID") @PathVariable Long profileId,
+                                                                     @PageableDefault(size = 8) Pageable pageable){
+        CharacterCollectionResponseDto responseDto = characterService.getCharacters(profileId, pageable);
         return ApiResponse.onSuccess(responseDto);
     }
 

--- a/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
+++ b/src/main/java/everTale/everTale_be/domain/character/service/CharacterService.java
@@ -4,6 +4,9 @@ import everTale.everTale_be.domain.character.dto.CharacterCollectionResponseDto;
 import everTale.everTale_be.domain.character.dto.CharacterDetailResponseDto;
 import everTale.everTale_be.domain.character.entity.StoryCharacter;
 import everTale.everTale_be.domain.character.repository.StoryCharacterRepository;
+import everTale.everTale_be.domain.profile.entity.Enum.ProfileType;
+import everTale.everTale_be.domain.profile.entity.Profile;
+import everTale.everTale_be.domain.profile.service.ProfileService;
 import everTale.everTale_be.domain.profile.util.ProfileHelper;
 import everTale.everTale_be.global.apiPayload.code.status.ErrorStatus;
 import everTale.everTale_be.global.apiPayload.exception.handler.NotFoundHandler;
@@ -19,11 +22,19 @@ import org.springframework.transaction.annotation.Transactional;
 public class CharacterService {
 
     private final ProfileHelper profileHelper;
+    private final ProfileService profileService;
     private final StoryCharacterRepository characterRepository;
 
     // 주인공 모음집 조회
-    public CharacterCollectionResponseDto getMyCharacters(Pageable pageable){
-        Long profileId = profileHelper.getAuthenticatedProfileId();
+    public CharacterCollectionResponseDto getCharacters(Long profileId, Pageable pageable){
+        Profile profile = profileHelper.getAuthenticatedProfile();
+
+        if (profile.getProfileType() == ProfileType.CHILD) {
+            profileService.validateChildProfileAccess(profile, profileId);
+        } else {
+            profileService.validateParentProfileAccess(profile, profileId);
+        }
+
         Page<StoryCharacter> characters = characterRepository.findByStoryProfileId(profileId, pageable);
         return CharacterCollectionResponseDto.from(characters);
     }

--- a/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
+++ b/src/main/java/everTale/everTale_be/domain/story/service/StoryService.java
@@ -318,7 +318,7 @@ public class StoryService {
     public StoryCollectionResponseDto getStories(Long profileId, Pageable pageable) {
         Profile profile = profileHelper.getAuthenticatedProfile();
 
-        if (profile.getProfileType()== ProfileType.CHILD) {
+        if (profile.getProfileType() == ProfileType.CHILD) {
             profileService.validateChildProfileAccess(profile, profileId);
         } else {
             profileService.validateParentProfileAccess(profile, profileId);

--- a/src/main/java/everTale/everTale_be/domain/voice/external/VoiceApiClient.java
+++ b/src/main/java/everTale/everTale_be/domain/voice/external/VoiceApiClient.java
@@ -42,7 +42,7 @@ public class VoiceApiClient {
             HttpEntity<MultiValueMap<String, Object>> requestEntity = new HttpEntity<>(body, headers);
 
             ResponseEntity<FastApiVoiceResponseDto> response = restTemplate.postForEntity(
-                    fastApiBaseUrl+"/ai/voice/register",
+                    fastApiBaseUrl + "/ai/voice/register",
                     requestEntity,
                     FastApiVoiceResponseDto.class
             );


### PR DESCRIPTION
## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
Character 조회 시, profileId로 특정 프로필 유저의 스토리 캐릭터 목록을 조회할 수 있도록 수정했습니다.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- Character 목록 조회
<img width="919" height="759" alt="스크린샷 2025-10-12 오후 8 16 28" src="https://github.com/user-attachments/assets/a5d1839b-eb36-4c40-ad79-1c7580972af1" />


## 📝 논의 사항
<!-- 리뷰어가 알아야 할 내용이나 추가 설명이 있다면 작성해주세요 -->
기존 캐릭터 상세 조회랑 api path가 겹쳐서 목록 조회는 `/characters/{profileId}` -> `/characters/list/{profileId}`로 수정했습니다.

---
