### PR TITLE
[refactor] 다른 사용자가 생성한 story의  quiz에 접근 가능하도록 변경

### DIFF
--- a/src/main/java/everTale/everTale_be/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/quiz/repository/QuizRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
     @EntityGraph(attributePaths = {"scene", "scene.story"})
-    List<Quiz> findAllByScene_Story_IdAndScene_Story_Profile_Id(Long storyId, Long profileId);
+    List<Quiz> findAllByScene_Story_Id(Long storyId);
 
     @Modifying
     @Transactional

--- a/src/main/java/everTale/everTale_be/domain/quiz/service/QuizService.java
+++ b/src/main/java/everTale/everTale_be/domain/quiz/service/QuizService.java
@@ -30,9 +30,7 @@ public class QuizService {
 
     @Transactional
     public QuizResponseDTO.QuizGenerateResponseDTO generateQuizForRandomScene(Long storyId) {
-        Long profileId = profileHelper.getAuthenticatedProfileId();
-
-        List<Scene> scenes = sceneRepository.findAllByStoryIdAndStoryProfileIdAndQuizIsNull(storyId, profileId);
+        List<Scene> scenes = sceneRepository.findAllByStoryIdAndQuizIsNull(storyId);
         if (scenes.isEmpty()) {
             throw new NotFoundHandler(ErrorStatus.SCENE_NOT_FOUND);
         }
@@ -58,8 +56,7 @@ public class QuizService {
     // quiz 조회
     @Transactional(readOnly = true)
     public List<QuizResponseDTO.QuizGetResponseDTO> getAllQuizzesByStoryId(Long storyId) {
-        Long profileId = profileHelper.getAuthenticatedProfileId();
-        List<Quiz> quizzes = quizRepository.findAllByScene_Story_IdAndScene_Story_Profile_Id(storyId, profileId);
+        List<Quiz> quizzes = quizRepository.findAllByScene_Story_Id(storyId);
 
         return quizzes.stream()
                 .map(QuizResponseDTO.QuizGetResponseDTO::from)

--- a/src/main/java/everTale/everTale_be/domain/story/repository/SceneRepository.java
+++ b/src/main/java/everTale/everTale_be/domain/story/repository/SceneRepository.java
@@ -20,7 +20,7 @@ public interface SceneRepository extends JpaRepository<Scene, Long> {
 
     List<Scene> findByStoryIdOrderByPageAsc(Long storyId);
 
-    List<Scene> findAllByStoryIdAndStoryProfileIdAndQuizIsNull(Long storyId, Long profileId);
+    List<Scene> findAllByStoryIdAndQuizIsNull(Long storyId);
 
     Optional<Scene> findByIdAndStoryId(Long sceneId, Long storyId);
 }


### PR DESCRIPTION
## 📌 개요
<!-- 어떤 작업을 했는지 요약해주세요 -->
- 다른 사용자가 생성한 story의 quiz에도 접근 가능하도록 변경한다.
- 따라서, 내가 생성한 스토리가 아니더라도 퀴즈를 생성하고 답변 성공 여부에 따라서 포인트를 쌓아서 칭호를 부여받을 수 있다.

## 🔧 작업 내용
<!-- 주요 변경 내용을 정리해주세요(캡처 + 설명) -->
- 테스트용으로 생성한 새로운 프로필(김혜이)가 다른 사용자가 생성한 스토리 정답을 맞춤
<img width="985" height="939" alt="스크린샷 2025-11-01 오후 11 05 09" src="https://github.com/user-attachments/assets/4ec2c9cb-fd98-401a-a298-230bdb0ebc2d" />

- 김혜이가 다른 사용자가 생성한 스토리에서 퀴즈를 풀 수 있음
<img width="985" height="939" alt="스크린샷 2025-11-01 오후 11 05 26" src="https://github.com/user-attachments/assets/74225299-aff8-4bdb-8874-6a82480191e9" />
